### PR TITLE
Add drag-and-drop for image upload

### DIFF
--- a/components/admin/icon-pickers/icon-upload.tsx
+++ b/components/admin/icon-pickers/icon-upload.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import { useState, useRef, useMemo, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
 import { Upload, X, ImageIcon } from 'lucide-react';
 import Image from 'next/image';
+
+import { Button } from '@/components/ui/button';
+import { FileDropzone } from '@/components/ui/file-dropzone';
 import { IMAGE_ACCEPT, IMAGE_TYPE_ERROR, IMAGE_TYPE_LABEL, MAX_FILE_SIZE, isAllowedImageMime } from '@/lib/image-constants';
+import { cn } from '@/lib/utils';
 
 interface IconUploadProps {
   value?: string;
@@ -35,8 +38,7 @@ export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey
     };
   }, [preview]);
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+  const selectFile = (file?: File | null) => {
     if (!file) return;
 
     setError(null);
@@ -44,14 +46,18 @@ export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey
     // Validate file size
     if (file.size > MAX_FILE_SIZE) {
       setError(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB.`);
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
       return;
     }
 
     // Validate file type
     if (!isAllowedImageMime(file.type)) {
       setError(IMAGE_TYPE_ERROR);
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
       return;
     }
 
@@ -61,6 +67,14 @@ export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
+  };
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    selectFile(e.target.files?.[0]);
+  };
+
+  const openFilePicker = () => {
+    fileInputRef.current?.click();
   };
 
   const handleClear = () => {
@@ -77,64 +91,82 @@ export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey
 
   return (
     <div className="space-y-3">
-      <div className="flex items-start gap-4">
-        {/* Icon Preview */}
-        <div className="flex-shrink-0">
-          <div className="w-16 h-16 rounded-lg border-2 border-dashed border-border flex items-center justify-center bg-muted/50 overflow-hidden">
-            {currentIcon ? (
-              <Image
-                src={currentIcon}
-                alt="Service icon"
-                width={64}
-                height={64}
-                className="object-cover w-full h-full"
-                unoptimized
-              />
-            ) : (
-              <ImageIcon className="w-6 h-6 text-muted-foreground" />
-            )}
-          </div>
-        </div>
-
-        {/* Upload Controls */}
-        <div className="flex-1 space-y-2">
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Upload className="w-4 h-4" />
-              {currentIcon ? 'Change Icon' : 'Upload Icon'}
-            </Button>
-
-            {currentIcon && (
+      <FileDropzone
+        className="min-h-24 rounded-lg border-2 border-dashed border-border bg-muted/20 p-3 transition-colors"
+        activeClassName="border-primary/70 bg-muted/30"
+        onFileDrop={selectFile}
+      >
+        {(isDragActive) => (
+          <div className="flex items-center gap-4">
+            {/* Icon Preview */}
+            <div className="flex-shrink-0">
               <Button
                 type="button"
-                variant="outline"
-                size="sm"
-                onClick={handleClear}
+                variant="ghost"
+                size="icon"
+                onClick={openFilePicker}
+                className={cn(
+                  'w-16 h-16 rounded-lg border border-border/70 flex items-center justify-center bg-muted/50 overflow-hidden p-0 hover:bg-muted/70',
+                  isDragActive && 'border-primary/70'
+                )}
+                aria-label={currentIcon ? 'Change icon' : 'Upload icon'}
               >
-                <X className="w-4 h-4" />
-                Remove
+                {currentIcon ? (
+                  <Image
+                    src={currentIcon}
+                    alt="Service icon"
+                    width={64}
+                    height={64}
+                    className="object-cover w-full h-full"
+                    unoptimized
+                  />
+                ) : (
+                  <ImageIcon className="w-6 h-6 text-muted-foreground" />
+                )}
               </Button>
-            )}
+            </div>
 
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={IMAGE_ACCEPT}
-              onChange={handleFileSelect}
-              className="hidden"
-            />
+            {/* Upload Controls */}
+            <div className="flex-1 space-y-2">
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={openFilePicker}
+                >
+                  <Upload className="w-4 h-4" />
+                  {currentIcon ? 'Change Icon' : 'Upload Icon'}
+                </Button>
+
+                {currentIcon && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleClear}
+                  >
+                    <X className="w-4 h-4" />
+                    Remove
+                  </Button>
+                )}
+
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={IMAGE_ACCEPT}
+                  onChange={handleFileSelect}
+                  className="hidden"
+                />
+              </div>
+
+              <p className="text-xs text-muted-foreground">
+                {IMAGE_TYPE_LABEL} (max {MAX_FILE_SIZE / 1024 / 1024}MB)
+              </p>
+            </div>
           </div>
-
-          <p className="text-xs text-muted-foreground">
-            {IMAGE_TYPE_LABEL} (max {MAX_FILE_SIZE / 1024 / 1024}MB)
-          </p>
-        </div>
-      </div>
+        )}
+      </FileDropzone>
 
       {/* Error Message */}
       {error && (

--- a/components/ui/file-dropzone.tsx
+++ b/components/ui/file-dropzone.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+interface FileDropzoneProps {
+  className?: string;
+  activeClassName?: string;
+  disabled?: boolean;
+  onFileDrop: (file?: File | null) => void;
+  children: React.ReactNode | ((isDragActive: boolean) => React.ReactNode);
+}
+
+export function FileDropzone({
+  className,
+  activeClassName,
+  disabled = false,
+  onFileDrop,
+  children,
+}: FileDropzoneProps) {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const dragDepthRef = useRef(0);
+
+  const hasFiles = (types: readonly string[]) => types.includes('Files');
+
+  const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled || !hasFiles(e.dataTransfer.types)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current += 1;
+    setIsDragActive(true);
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled || !hasFiles(e.dataTransfer.types)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    e.dataTransfer.dropEffect = 'copy';
+    setIsDragActive(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled || !hasFiles(e.dataTransfer.types)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = Math.max(dragDepthRef.current - 1, 0);
+    if (dragDepthRef.current === 0) {
+      setIsDragActive(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    if (disabled || !hasFiles(e.dataTransfer.types)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    dragDepthRef.current = 0;
+    setIsDragActive(false);
+    onFileDrop(e.dataTransfer.files?.[0]);
+  };
+
+  return (
+    <div
+      className={cn(className, isDragActive && activeClassName)}
+      onDragEnter={handleDragEnter}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      {typeof children === 'function' ? children(isDragActive) : children}
+    </div>
+  );
+}


### PR DESCRIPTION
- Add drag-and-drop image upload support for service icon uploader, with reusable helper component.
- Make clicking the icon preview trigger the same file picker flow as clicking the “Upload Icon” button.