### PR TITLE
Add auto favicon fetch support for service icons

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-build:
-    name: Lint and Build
+  lint-and-test:
+    name: Lint and Test
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -37,5 +37,5 @@ jobs:
       - name: Run lint
         run: pnpm lint
 
-      - name: Run build
-        run: pnpm build
+      - name: Run tests
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-test:
-    name: Lint and Test
+  lint-test-and-build:
+    name: Lint, Test, and Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -39,3 +39,6 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Run build
+        run: pnpm build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+/.pnpm-store
 /.pnp
 .pnp.*
 .yarn/*

--- a/components/admin/icon-pickers/icon-picker.tsx
+++ b/components/admin/icon-pickers/icon-picker.tsx
@@ -14,6 +14,9 @@ interface IconPickerBaseProps {
   onClear: () => void;
   cacheKey?: number;
   disabled?: boolean;
+  onFetchImageFromUrl?: () => void;
+  fetchImageDisabled?: boolean;
+  isFetchingImage?: boolean;
 }
 
 type IconPickerProps =
@@ -44,6 +47,9 @@ function IconPickerInner({
   pendingFile,
   onValueChange,
   onFileSelect,
+  onFetchImageFromUrl,
+  fetchImageDisabled,
+  isFetchingImage,
   onClear,
   allowImage,
   cacheKey,
@@ -129,6 +135,9 @@ function IconPickerInner({
             onFileSelect={handleImageFileSelect}
             onClear={onClear}
             cacheKey={cacheKey}
+            onFetchFromUrl={onFetchImageFromUrl}
+            fetchDisabled={disabled || fetchImageDisabled}
+            isFetching={isFetchingImage}
           />
         </TabsContent>
       )}

--- a/components/admin/icon-pickers/icon-upload.tsx
+++ b/components/admin/icon-pickers/icon-upload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useMemo, useEffect } from 'react';
-import { Upload, X, ImageIcon } from 'lucide-react';
+import { Globe, Upload, X, ImageIcon } from 'lucide-react';
 import Image from 'next/image';
 
 import { Button } from '@/components/ui/button';
@@ -15,9 +15,21 @@ interface IconUploadProps {
   onFileSelect: (file: File | null) => void;
   onClear: () => void;
   cacheKey?: number;
+  onFetchFromUrl?: () => void;
+  fetchDisabled?: boolean;
+  isFetching?: boolean;
 }
 
-export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey }: IconUploadProps) {
+export function IconUpload({
+  value,
+  pendingFile,
+  onFileSelect,
+  onClear,
+  cacheKey,
+  onFetchFromUrl,
+  fetchDisabled,
+  isFetching,
+}: IconUploadProps) {
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -136,8 +148,21 @@ export function IconUpload({ value, pendingFile, onFileSelect, onClear, cacheKey
                   onClick={openFilePicker}
                 >
                   <Upload className="w-4 h-4" />
-                  {currentIcon ? 'Change Icon' : 'Upload Icon'}
+                  Upload file
                 </Button>
+
+                {onFetchFromUrl && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onFetchFromUrl}
+                    disabled={fetchDisabled || isFetching}
+                  >
+                    <Globe className="w-4 h-4" />
+                    {isFetching ? 'Fetching...' : 'Fetch favicon'}
+                  </Button>
+                )}
 
                 {currentIcon && (
                   <Button

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,7 +18,7 @@ import { Field, FieldLabel, FieldError, FieldDescription } from '@/components/ui
 import { IconPicker } from '../icon-pickers/icon-picker';
 import { CategoryIcon } from '@/components/common/icons/category-icon';
 import { resolveLucideIconName } from '@/lib/lucide-icons';
-import { createService, updateService, uploadServiceIcon } from '@/lib/actions';
+import { cleanupFetchedServiceIcon, createService, fetchServiceIcon, updateService, uploadServiceIcon } from '@/lib/actions';
 import { slugify } from '@/lib/utils';
 import { ICON_TYPES, type Category, type IconConfig, type Service } from '@/lib/types';
 
@@ -28,6 +28,32 @@ interface ServiceFormProps {
   onSuccess?: () => void;
   onCancel?: () => void;
   cacheKey?: number;
+}
+
+interface FetchedIconRef {
+  serviceId: string;
+  iconPath: string;
+}
+
+function parseServiceUrl(value: string): string | null {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+    return parsed.href;
+  } catch {
+    return null;
+  }
+}
+
+function getIconFetchId(serviceId: string, serviceUrl: string): string {
+  if (serviceId) return serviceId;
+
+  try {
+    const hostname = new URL(serviceUrl).hostname.replace(/^www\./, '');
+    return slugify(hostname) || 'service';
+  } catch {
+    return 'service';
+  }
 }
 
 export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey }: ServiceFormProps) {
@@ -40,9 +66,57 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
   const [active, setActive] = useState(service?.active ?? true);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isFetchingIcon, setIsFetchingIcon] = useState(false);
+  const [iconVersion, setIconVersion] = useState(0);
+  const [iconControl, setIconControl] = useState<'auto' | 'manual'>(service ? 'manual' : 'auto');
+  const urlRef = useRef(url);
+  const lastAutoFetchKeyRef = useRef<string | null>(null);
+  const autoFetchRequestRef = useRef(0);
+  const provisionalIconRef = useRef<FetchedIconRef | null>(null);
 
   // Generate slug from name for new services
   const serviceId = service?.id || slugify(name);
+  const iconCacheKey = (cacheKey ?? 0) + iconVersion;
+
+  const getValidServiceUrl = useCallback((): string | null => parseServiceUrl(url), [url]);
+
+  useEffect(() => {
+    urlRef.current = url;
+  }, [url]);
+
+  const getLatestValidServiceUrl = useCallback((): string | null => parseServiceUrl(urlRef.current), []);
+
+  const cleanupFetchedIcon = useCallback((iconRef: FetchedIconRef) => {
+    const formData = new FormData();
+    formData.append('serviceId', iconRef.serviceId);
+    formData.append('iconPath', iconRef.iconPath);
+
+    void cleanupFetchedServiceIcon(formData);
+  }, []);
+
+  const trackProvisionalIcon = useCallback((iconRef: FetchedIconRef) => {
+    const previousIcon = provisionalIconRef.current;
+
+    if (previousIcon && previousIcon.iconPath !== iconRef.iconPath) {
+      cleanupFetchedIcon(previousIcon);
+    }
+
+    provisionalIconRef.current = iconRef;
+  }, [cleanupFetchedIcon]);
+
+  const releaseProvisionalIcon = useCallback((keptIconPath?: string) => {
+    const currentIcon = provisionalIconRef.current;
+    if (!currentIcon) return;
+
+    provisionalIconRef.current = null;
+    if (currentIcon.iconPath !== keptIconPath) {
+      cleanupFetchedIcon(currentIcon);
+    }
+  }, [cleanupFetchedIcon]);
+
+  useEffect(() => () => {
+    releaseProvisionalIcon();
+  }, [releaseProvisionalIcon]);
 
   const uploadIcon = async (file: File, id: string): Promise<string | null> => {
     const formData = new FormData();
@@ -51,6 +125,173 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
 
     const result = await uploadServiceIcon(formData);
     return result.success ? result.data : null;
+  };
+
+  const handleFetchFavicon = useCallback(async ({
+    silent = false,
+    markManual = true,
+    expectedUrl,
+  }: {
+    silent?: boolean;
+    markManual?: boolean;
+    expectedUrl?: string;
+  } = {}) => {
+    if (!url || isSubmitting || isFetchingIcon) return;
+    const validUrl = getValidServiceUrl();
+    if (!validUrl) return;
+    const iconFetchId = getIconFetchId(serviceId, validUrl);
+
+    if (markManual) {
+      setIconControl('manual');
+    }
+    setIsFetchingIcon(true);
+    if (!silent) {
+      setErrors((current) => {
+        const next = { ...current };
+        delete next.icon;
+        delete next.url;
+        return next;
+      });
+    }
+
+    const formData = new FormData();
+    formData.append('serviceId', iconFetchId);
+    formData.append('url', validUrl);
+
+    const result = await fetchServiceIcon(formData);
+    if (getLatestValidServiceUrl() !== validUrl || (silent && expectedUrl && validUrl !== expectedUrl)) {
+      if (result.success) {
+        cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+      }
+      setIsFetchingIcon(false);
+      return;
+    }
+
+    if (result.success) {
+      trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
+      setPendingIconFile(null);
+      setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
+      setIconVersion((value) => value + 1);
+      if (!silent) {
+        toast.success('Favicon fetched');
+      }
+    } else {
+      if (!silent) {
+        const errorMap: Record<string, string> = {};
+        result.errors.forEach((error) => {
+          errorMap[error.field] = error.message;
+        });
+        setErrors((current) => ({ ...current, ...errorMap }));
+        toast.error(result.errors[0]?.message ?? 'Failed to fetch favicon');
+      }
+    }
+
+    setIsFetchingIcon(false);
+  }, [
+    cleanupFetchedIcon,
+    getLatestValidServiceUrl,
+    getValidServiceUrl,
+    isFetchingIcon,
+    isSubmitting,
+    serviceId,
+    trackProvisionalIcon,
+    url,
+  ]);
+
+  useEffect(() => {
+    if (service || iconControl !== 'auto' || pendingIconFile || isSubmitting) return;
+
+    const validUrl = getValidServiceUrl();
+    if (!validUrl) return;
+
+    const iconFetchId = getIconFetchId(serviceId, validUrl);
+    const fetchKey = `${iconFetchId}:${validUrl}`;
+    if (lastAutoFetchKeyRef.current === fetchKey) return;
+
+    const timeout = window.setTimeout(() => {
+      const requestId = autoFetchRequestRef.current + 1;
+      autoFetchRequestRef.current = requestId;
+      setIsFetchingIcon(true);
+
+      const formData = new FormData();
+      formData.append('serviceId', iconFetchId);
+      formData.append('url', validUrl);
+
+      void fetchServiceIcon(formData).then((result) => {
+        if (
+          autoFetchRequestRef.current !== requestId ||
+          getLatestValidServiceUrl() !== validUrl
+        ) {
+          if (result.success) {
+            cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+          }
+          return;
+        }
+
+        lastAutoFetchKeyRef.current = fetchKey;
+
+        if (result.success) {
+          trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
+          setPendingIconFile(null);
+          setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
+          setIconVersion((value) => value + 1);
+        }
+      }).finally(() => {
+        if (autoFetchRequestRef.current === requestId) {
+          setIsFetchingIcon(false);
+        }
+      });
+    }, 600);
+
+    return () => window.clearTimeout(timeout);
+  }, [
+    cleanupFetchedIcon,
+    service,
+    iconControl,
+    pendingIconFile,
+    isSubmitting,
+    serviceId,
+    getLatestValidServiceUrl,
+    getValidServiceUrl,
+    trackProvisionalIcon,
+  ]);
+
+  const handleUrlChange = (nextUrl: string) => {
+    urlRef.current = nextUrl;
+    setUrl(nextUrl);
+
+    if (service || iconControl !== 'auto') return;
+
+    autoFetchRequestRef.current += 1;
+    lastAutoFetchKeyRef.current = null;
+    if (icon?.type === ICON_TYPES.IMAGE) {
+      releaseProvisionalIcon();
+      setIcon(undefined);
+      setIconVersion((value) => value + 1);
+    }
+  };
+
+  const handleIconValueChange = (nextIcon: IconConfig | undefined) => {
+    autoFetchRequestRef.current += 1;
+    releaseProvisionalIcon();
+    setIconControl('manual');
+    setIcon(nextIcon);
+  };
+
+  const handleIconFileSelect = (file: File | null) => {
+    if (file) {
+      autoFetchRequestRef.current += 1;
+      releaseProvisionalIcon();
+      setIconControl('manual');
+    }
+    setPendingIconFile(file);
+  };
+
+  const handleIconClear = () => {
+    autoFetchRequestRef.current += 1;
+    releaseProvisionalIcon();
+    setIconControl('manual');
+    setIcon(undefined);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -86,12 +327,42 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       }
     }
 
+    if (!service && iconControl === 'auto' && finalIcon?.type === ICON_TYPES.IMAGE && serviceId) {
+      const filename = finalIcon.value.split('/').pop() ?? '';
+      const basename = filename.replace(/\.[^.]+$/, '');
+
+      if (basename !== serviceId) {
+        const validUrl = getValidServiceUrl();
+        let refreshedIcon: IconConfig | undefined;
+
+        if (validUrl) {
+          const formData = new FormData();
+          formData.append('serviceId', serviceId);
+          formData.append('url', validUrl);
+
+          const result = await fetchServiceIcon(formData);
+          if (result.success) {
+            refreshedIcon = { type: ICON_TYPES.IMAGE, value: result.data };
+            trackProvisionalIcon({ serviceId, iconPath: result.data });
+          }
+        }
+
+        finalIcon = refreshedIcon;
+        setIcon(refreshedIcon);
+        setIconVersion((value) => value + 1);
+        if (!refreshedIcon) {
+          releaseProvisionalIcon();
+        }
+      }
+    }
+
     const formData = { name, description, url, categoryId, icon: finalIcon, active };
     const result = service
       ? await updateService(service.id, formData)
-      : await createService({ id: serviceId, ...formData });
+      : await createService({ id: serviceId, ...formData, fetchFavicon: iconControl === 'auto' });
 
     if (result.success) {
+      releaseProvisionalIcon(finalIcon?.type === ICON_TYPES.IMAGE ? finalIcon.value : undefined);
       toast.success(service ? 'Service updated' : 'Service created');
       setName('');
       setDescription('');
@@ -99,6 +370,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       setCategoryId('');
       setIcon(undefined);
       setPendingIconFile(null);
+      setIconControl('auto');
       setActive(true);
       onSuccess?.();
     } else {
@@ -144,7 +416,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         <FieldLabel>URL *</FieldLabel>
         <Input
           value={url}
-          onChange={(e) => setUrl(e.target.value)}
+          onChange={(e) => handleUrlChange(e.target.value)}
           placeholder="https://example.com, http://192.168.1.1:8080"
           type="url"
           disabled={isSubmitting}
@@ -180,10 +452,13 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
           value={icon}
           allowImage={true}
           pendingFile={pendingIconFile}
-          onValueChange={setIcon}
-          onFileSelect={setPendingIconFile}
-          onClear={() => setIcon(undefined)}
-          cacheKey={cacheKey}
+          onValueChange={handleIconValueChange}
+          onFileSelect={handleIconFileSelect}
+          onFetchImageFromUrl={handleFetchFavicon}
+          fetchImageDisabled={!getValidServiceUrl() || isSubmitting}
+          isFetchingImage={isFetchingIcon}
+          onClear={handleIconClear}
+          cacheKey={iconCacheKey}
         />
         {errors.icon && <FieldError>{errors.icon}</FieldError>}
       </Field>

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -327,42 +327,13 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       }
     }
 
-    if (!service && iconControl === 'auto' && finalIcon?.type === ICON_TYPES.IMAGE && serviceId) {
-      const filename = finalIcon.value.split('/').pop() ?? '';
-      const basename = filename.replace(/\.[^.]+$/, '');
-
-      if (basename !== serviceId) {
-        const validUrl = getValidServiceUrl();
-        let refreshedIcon: IconConfig | undefined;
-
-        if (validUrl) {
-          const formData = new FormData();
-          formData.append('serviceId', serviceId);
-          formData.append('url', validUrl);
-
-          const result = await fetchServiceIcon(formData);
-          if (result.success) {
-            refreshedIcon = { type: ICON_TYPES.IMAGE, value: result.data };
-            trackProvisionalIcon({ serviceId, iconPath: result.data });
-          }
-        }
-
-        finalIcon = refreshedIcon;
-        setIcon(refreshedIcon);
-        setIconVersion((value) => value + 1);
-        if (!refreshedIcon) {
-          releaseProvisionalIcon();
-        }
-      }
-    }
-
     const formData = { name, description, url, categoryId, icon: finalIcon, active };
     const result = service
       ? await updateService(service.id, formData)
       : await createService({ id: serviceId, ...formData, fetchFavicon: iconControl === 'auto' });
 
     if (result.success) {
-      releaseProvisionalIcon(finalIcon?.type === ICON_TYPES.IMAGE ? finalIcon.value : undefined);
+      releaseProvisionalIcon(result.data.icon?.type === ICON_TYPES.IMAGE ? result.data.icon.value : undefined);
       toast.success(service ? 'Service updated' : 'Service created');
       setName('');
       setDescription('');

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -158,25 +158,24 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     formData.append('serviceId', iconFetchId);
     formData.append('url', validUrl);
 
-    const result = await fetchServiceIcon(formData);
-    if (getLatestValidServiceUrl() !== validUrl || (silent && expectedUrl && validUrl !== expectedUrl)) {
-      if (result.success) {
-        cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+    try {
+      const result = await fetchServiceIcon(formData);
+      if (getLatestValidServiceUrl() !== validUrl || (silent && expectedUrl && validUrl !== expectedUrl)) {
+        if (result.success) {
+          cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+        }
+        return;
       }
-      setIsFetchingIcon(false);
-      return;
-    }
 
-    if (result.success) {
-      trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
-      setPendingIconFile(null);
-      setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
-      setIconVersion((value) => value + 1);
-      if (!silent) {
-        toast.success('Favicon fetched');
-      }
-    } else {
-      if (!silent) {
+      if (result.success) {
+        trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
+        setPendingIconFile(null);
+        setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
+        setIconVersion((value) => value + 1);
+        if (!silent) {
+          toast.success('Favicon fetched');
+        }
+      } else if (!silent) {
         const errorMap: Record<string, string> = {};
         result.errors.forEach((error) => {
           errorMap[error.field] = error.message;
@@ -184,9 +183,14 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         setErrors((current) => ({ ...current, ...errorMap }));
         toast.error(result.errors[0]?.message ?? 'Failed to fetch favicon');
       }
+    } catch {
+      if (!silent) {
+        setErrors((current) => ({ ...current, icon: 'Failed to fetch favicon' }));
+        toast.error('Failed to fetch favicon');
+      }
+    } finally {
+      setIsFetchingIcon(false);
     }
-
-    setIsFetchingIcon(false);
   }, [
     cleanupFetchedIcon,
     getLatestValidServiceUrl,

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -1,12 +1,12 @@
 'use server';
 
 import { createHash } from 'crypto';
-import { promises as fs } from 'fs';
 import path from 'path';
 import { ZodError } from 'zod';
 import { revalidatePath } from 'next/cache';
 import { collectConfigImportWarnings } from './config-import';
 import { readConfig, readRawConfig, writeConfig, writeRawConfigIfRevisionMatches } from './db';
+import { fetchProvisionalServiceFavicon, fetchServiceFavicon } from './favicon';
 import {
   appSettingsSchema,
   categorySchema,
@@ -16,7 +16,16 @@ import {
   serviceCreateSchema,
   serviceIdSchema,
 } from './validations';
-import { deleteAppLogo, deleteServiceIcon, getAppLogoFilename, getIconFilePath, isValidImageExtension } from './file-utils';
+import {
+  deleteAppLogo,
+  deleteIconFile,
+  deleteServiceIcon,
+  getAppLogoFilename,
+  isProvisionalIconPath,
+  isValidImageExtension,
+  promoteProvisionalIcon,
+  writeIconBuffer,
+} from './file-utils';
 import { IMAGE_TYPE_ERROR, MAX_FILE_SIZE, isAllowedImageMime } from './image-constants';
 import {
   ICON_TYPES,
@@ -49,6 +58,18 @@ type SaveConfigJsonResult = ImportConfigResult & {
   revision: string;
 };
 
+async function getPromotedServiceIcon(icon: IconConfig | undefined, serviceId: string): Promise<IconConfig | undefined> {
+  if (icon?.type !== ICON_TYPES.IMAGE || !isProvisionalIconPath(icon.value)) {
+    return icon;
+  }
+
+  const iconPath = await promoteProvisionalIcon(icon.value, serviceId);
+  return {
+    type: ICON_TYPES.IMAGE,
+    value: iconPath,
+  };
+}
+
 function validateImageFile(file: File, fieldName: string): { success: false; errors: { field: string; message: string }[] } | null {
   if (!isAllowedImageMime(file.type)) {
     return { success: false, errors: [{ field: fieldName, message: IMAGE_TYPE_ERROR }] };
@@ -63,31 +84,10 @@ function validateImageFile(file: File, fieldName: string): { success: false; err
 }
 
 async function writeIconFile(file: File, filename: string, baseNameForCleanup: string): Promise<string> {
-  const filePath = getIconFilePath(filename);
-  const iconsDir = path.dirname(filePath);
-  const tempPath = path.join(iconsDir, `${filename}.tmp-${crypto.randomUUID()}`);
-
-  await fs.mkdir(iconsDir, { recursive: true });
-
-  const existingIcons = await fs.readdir(iconsDir).catch(() => []);
-  const oldFiles = existingIcons.filter((f) => path.parse(f).name === baseNameForCleanup && f !== filename);
-
   const bytes = await file.arrayBuffer();
   const buffer = Buffer.from(bytes);
 
-  try {
-    await fs.writeFile(tempPath, buffer);
-    await fs.rename(tempPath, filePath);
-  } catch (error) {
-    await fs.unlink(tempPath).catch(() => {});
-    throw error;
-  }
-
-  for (const oldFile of oldFiles) {
-    await fs.unlink(path.join(iconsDir, oldFile)).catch(() => {});
-  }
-
-  return `icons/${filename}`;
+  return writeIconBuffer(buffer, filename, baseNameForCleanup);
 }
 
 function mapValidationIssues(error: ZodError): Array<{ field: string; message: string }> {
@@ -189,6 +189,70 @@ export async function uploadServiceIcon(formData: FormData): Promise<ActionResul
   } catch (error) {
     console.error('Upload error:', error);
     return { success: false, errors: [{ field: 'icon', message: 'Failed to upload file' }] };
+  }
+}
+
+export async function fetchServiceIcon(formData: FormData): Promise<ActionResult<string>> {
+  try {
+    const serviceId = formData.get('serviceId') as string;
+    const serviceUrl = formData.get('url') as string;
+
+    if (!serviceId) {
+      return { success: false, errors: [{ field: 'icon', message: 'No service ID provided' }] };
+    }
+
+    const idValidation = serviceIdSchema.safeParse(serviceId);
+    if (!idValidation.success) {
+      return {
+        success: false,
+        errors: [{ field: 'icon', message: idValidation.error.issues[0]?.message ?? 'Invalid service ID format' }],
+      };
+    }
+
+    const urlValidation = serviceSchema.shape.url.safeParse(serviceUrl);
+    if (!urlValidation.success) {
+      return {
+        success: false,
+        errors: [{ field: 'url', message: urlValidation.error.issues[0]?.message ?? 'Must be a valid URL' }],
+      };
+    }
+
+    const iconPath = await fetchProvisionalServiceFavicon(urlValidation.data);
+    if (!iconPath) {
+      return {
+        success: false,
+        errors: [{ field: 'icon', message: 'No favicon found for this URL' }],
+      };
+    }
+
+    revalidatePath('/');
+    revalidatePath('/admin');
+
+    return { success: true, data: iconPath };
+  } catch (error) {
+    console.error('Fetch service icon error:', error);
+    return { success: false, errors: [{ field: 'icon', message: 'Failed to fetch favicon' }] };
+  }
+}
+
+export async function cleanupFetchedServiceIcon(formData: FormData): Promise<ActionResult<void>> {
+  try {
+    const iconPath = formData.get('iconPath');
+
+    if (typeof iconPath !== 'string') {
+      return { success: false, errors: [{ field: 'icon', message: 'Invalid icon cleanup request' }] };
+    }
+
+    if (!isProvisionalIconPath(iconPath)) {
+      return { success: false, errors: [{ field: 'icon', message: 'Invalid icon path' }] };
+    }
+
+    await deleteIconFile(iconPath);
+
+    return { success: true, data: undefined };
+  } catch (error) {
+    console.error('Cleanup fetched service icon error:', error);
+    return { success: false, errors: [{ field: 'icon', message: 'Failed to clean up favicon' }] };
   }
 }
 
@@ -509,6 +573,7 @@ export async function deleteCategory(id: string): Promise<ActionResult<void>> {
 
 export async function createService(data: ServiceCreateData): Promise<ActionResult<Service>> {
   try {
+    const shouldFetchFavicon = data.fetchFavicon ?? true;
     const validated = serviceCreateSchema.parse({ ...data, active: data.active ?? true });
     const config = await readConfig();
 
@@ -530,10 +595,36 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
       };
     }
 
-    const newService: Service = validated;
+    let downloadedIconPath: string | null = null;
+    let promotedIconPath: string | null = null;
+    const newService: Service = {
+      ...validated,
+      icon: await getPromotedServiceIcon(validated.icon, validated.id),
+    };
+    if (
+      newService.icon?.type === ICON_TYPES.IMAGE &&
+      validated.icon?.type === ICON_TYPES.IMAGE &&
+      newService.icon.value !== validated.icon.value
+    ) {
+      promotedIconPath = newService.icon.value;
+    }
+
+    if (!newService.icon && shouldFetchFavicon) {
+      downloadedIconPath = await fetchServiceFavicon(newService.url, newService.id);
+      if (downloadedIconPath) {
+        newService.icon = { type: ICON_TYPES.IMAGE, value: downloadedIconPath };
+      }
+    }
 
     config.services.push(newService);
-    await writeConfig(config);
+    try {
+      await writeConfig(config);
+    } catch (error) {
+      if (downloadedIconPath || promotedIconPath) {
+        await deleteServiceIcon(newService.id);
+      }
+      throw error;
+    }
 
     revalidatePath('/');
     revalidatePath('/admin');
@@ -587,9 +678,11 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
     }
 
     const previousService = config.services[index];
+    const nextIcon = await getPromotedServiceIcon(validated.icon, idValidation.data);
     const updatedService: Service = {
       ...config.services[index],
       ...validated,
+      icon: nextIcon,
     };
 
     config.services[index] = updatedService;
@@ -598,7 +691,7 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
     // If we are moving away from an image icon, remove the old image file after the config persists
     if (
       previousService.icon?.type === ICON_TYPES.IMAGE &&
-      validated.icon?.type !== ICON_TYPES.IMAGE
+      nextIcon?.type !== ICON_TYPES.IMAGE
     ) {
       await deleteServiceIcon(id);
     }

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -17,6 +17,7 @@ import {
   serviceIdSchema,
 } from './validations';
 import {
+  backupServiceIconFiles,
   deleteAppLogo,
   deleteIconFile,
   deleteServiceIcon,
@@ -24,6 +25,7 @@ import {
   isProvisionalIconPath,
   isValidImageExtension,
   promoteProvisionalIcon,
+  restoreServiceIconFiles,
   writeIconBuffer,
 } from './file-utils';
 import { IMAGE_TYPE_ERROR, MAX_FILE_SIZE, isAllowedImageMime } from './image-constants';
@@ -678,6 +680,10 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
     }
 
     const previousService = config.services[index];
+    const existingIconBackup =
+      validated.icon?.type === ICON_TYPES.IMAGE && isProvisionalIconPath(validated.icon.value)
+        ? await backupServiceIconFiles(idValidation.data)
+        : null;
     const nextIcon = await getPromotedServiceIcon(validated.icon, idValidation.data);
     const updatedService: Service = {
       ...config.services[index],
@@ -686,7 +692,14 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
     };
 
     config.services[index] = updatedService;
-    await writeConfig(config);
+    try {
+      await writeConfig(config);
+    } catch (error) {
+      if (existingIconBackup) {
+        await restoreServiceIconFiles(idValidation.data, existingIconBackup);
+      }
+      throw error;
+    }
 
     // If we are moving away from an image icon, remove the old image file after the config persists
     if (

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -227,9 +227,6 @@ export async function fetchServiceIcon(formData: FormData): Promise<ActionResult
       };
     }
 
-    revalidatePath('/');
-    revalidatePath('/admin');
-
     return { success: true, data: iconPath };
   } catch (error) {
     console.error('Fetch service icon error:', error);

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,10 +2,9 @@ import { createHash, randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { dashboardConfigImportSchema } from './validations';
+import { getConfigLockPath, getConfigPath } from './paths';
 import type { Category, Service, DashboardConfig, IconConfig } from './types';
 
-const CONFIG_PATH = path.join(process.cwd(), 'data', 'config.json');
-const CONFIG_LOCK_PATH = `${CONFIG_PATH}.lock`;
 const CONFIG_LOCK_TIMEOUT_MS = 5_000;
 const CONFIG_LOCK_RETRY_MS = 50;
 const CONFIG_LOCK_STALE_MS = 30_000;
@@ -31,17 +30,18 @@ function getConfigRevision(raw: string): string {
 }
 
 async function ensureConfigDirectory(): Promise<void> {
-  await fs.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
+  await fs.mkdir(path.dirname(getConfigPath()), { recursive: true });
 }
 
 async function writeRawConfigAtomic(raw: string): Promise<void> {
   await ensureConfigDirectory();
 
-  const tempPath = path.join(path.dirname(CONFIG_PATH), `${path.basename(CONFIG_PATH)}.tmp-${randomUUID()}`);
+  const configPath = getConfigPath();
+  const tempPath = path.join(path.dirname(configPath), `${path.basename(configPath)}.tmp-${randomUUID()}`);
 
   try {
     await fs.writeFile(tempPath, raw, 'utf-8');
-    await fs.rename(tempPath, CONFIG_PATH);
+    await fs.rename(tempPath, configPath);
   } catch (error) {
     await fs.unlink(tempPath).catch(() => {});
     throw error;
@@ -50,7 +50,7 @@ async function writeRawConfigAtomic(raw: string): Promise<void> {
 
 async function readRawConfigFile(): Promise<string | null> {
   try {
-    return await fs.readFile(CONFIG_PATH, 'utf-8');
+    return await fs.readFile(getConfigPath(), 'utf-8');
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return null;
@@ -89,10 +89,11 @@ async function acquireConfigLock(): Promise<void> {
   await ensureConfigDirectory();
 
   const deadline = Date.now() + CONFIG_LOCK_TIMEOUT_MS;
+  const lockPath = getConfigLockPath();
 
   while (true) {
     try {
-      const handle = await fs.open(CONFIG_LOCK_PATH, 'wx');
+      const handle = await fs.open(lockPath, 'wx');
       await handle.close();
       return;
     } catch (error) {
@@ -101,9 +102,9 @@ async function acquireConfigLock(): Promise<void> {
         throw new Error('Failed to lock configuration');
       }
 
-      const stats = await fs.stat(CONFIG_LOCK_PATH).catch(() => null);
+      const stats = await fs.stat(lockPath).catch(() => null);
       if (stats && Date.now() - stats.mtimeMs > CONFIG_LOCK_STALE_MS) {
-        await fs.unlink(CONFIG_LOCK_PATH).catch(() => {});
+        await fs.unlink(lockPath).catch(() => {});
         continue;
       }
 
@@ -117,7 +118,7 @@ async function acquireConfigLock(): Promise<void> {
 }
 
 async function releaseConfigLock(): Promise<void> {
-  await fs.unlink(CONFIG_LOCK_PATH).catch(() => {});
+  await fs.unlink(getConfigLockPath()).catch(() => {});
 }
 
 async function withConfigLock<T>(callback: () => Promise<T>): Promise<T> {

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -1,0 +1,320 @@
+import path from 'path';
+import {
+  MAX_FILE_SIZE,
+  getImageExtensionForContentType,
+  isAllowedImageExtension,
+  isAllowedImageMime,
+} from './image-constants';
+import { getProvisionalIconFilename, writeIconBuffer } from './file-utils';
+
+const FAVICON_FETCH_TIMEOUT_MS = 4_000;
+const FAVICON_PAGE_MAX_BYTES = 512 * 1024;
+const FAVICON_MAX_REDIRECTS = 3;
+const FAVICON_USER_AGENT = 'crapdash-favicon-fetcher/1.0';
+
+interface IconCandidate {
+  url: URL;
+  rel: string;
+  type?: string;
+  sizes?: string;
+  source: 'html' | 'fallback';
+}
+
+function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function getTimeoutSignal(): AbortSignal {
+  return AbortSignal.timeout(FAVICON_FETCH_TIMEOUT_MS);
+}
+
+function normalizeContentType(value: string | null): string {
+  return value?.toLowerCase().split(';')[0]?.trim() ?? '';
+}
+
+function parseAttributes(tag: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrPattern = /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+  for (const match of tag.matchAll(attrPattern)) {
+    const [, rawName, doubleQuoted, singleQuoted, unquoted] = match;
+    if (!rawName || rawName.toLowerCase() === 'link') continue;
+    attrs[rawName.toLowerCase()] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+  }
+
+  return attrs;
+}
+
+function parseIconCandidates(html: string, baseUrl: URL): IconCandidate[] {
+  const candidates: IconCandidate[] = [];
+  const linkPattern = /<link\b[^>]*>/gi;
+
+  for (const match of html.matchAll(linkPattern)) {
+    const attrs = parseAttributes(match[0]);
+    const rel = attrs.rel?.toLowerCase() ?? '';
+    const href = attrs.href;
+
+    if (!href || !rel.split(/\s+/).some((part) => part === 'icon' || part.startsWith('apple-touch-icon'))) {
+      continue;
+    }
+
+    try {
+      const url = new URL(href, baseUrl);
+      if (!isHttpUrl(url) || url.origin !== baseUrl.origin) continue;
+
+      candidates.push({
+        url,
+        rel,
+        type: attrs.type,
+        sizes: attrs.sizes,
+        source: 'html',
+      });
+    } catch {
+      // Ignore malformed icon hrefs.
+    }
+  }
+
+  return candidates;
+}
+
+function getLargestDeclaredSize(sizes?: string): number {
+  if (!sizes || sizes.toLowerCase() === 'any') return 0;
+
+  return sizes
+    .split(/\s+/)
+    .map((size) => {
+      const match = /^(\d+)x(\d+)$/i.exec(size);
+      if (!match) return 0;
+      return Math.max(Number(match[1]), Number(match[2]));
+    })
+    .reduce((max, size) => Math.max(max, size), 0);
+}
+
+function scoreCandidate(candidate: IconCandidate): number {
+  const pathname = candidate.url.pathname.toLowerCase();
+  const declaredType = normalizeContentType(candidate.type ?? null);
+  const declaredSize = getLargestDeclaredSize(candidate.sizes);
+  let score = candidate.source === 'html' ? 100 : 10;
+
+  if (candidate.rel.includes('apple-touch-icon')) score += 18;
+  if (declaredSize >= 128) score += 20;
+  else if (declaredSize >= 64) score += 12;
+  else if (declaredSize >= 32) score += 8;
+
+  if (declaredType === 'image/svg+xml' || pathname.endsWith('.svg')) score += 16;
+  else if (declaredType === 'image/png' || pathname.endsWith('.png')) score += 14;
+  else if (declaredType === 'image/webp' || pathname.endsWith('.webp')) score += 12;
+  else if (declaredType === 'image/x-icon' || pathname.endsWith('.ico')) score += 4;
+
+  return score;
+}
+
+function dedupeAndSortCandidates(candidates: IconCandidate[]): IconCandidate[] {
+  const byUrl = new Map<string, IconCandidate>();
+
+  for (const candidate of candidates) {
+    const key = candidate.url.href;
+    const existing = byUrl.get(key);
+    if (!existing || scoreCandidate(candidate) > scoreCandidate(existing)) {
+      byUrl.set(key, candidate);
+    }
+  }
+
+  return [...byUrl.values()].sort((a, b) => scoreCandidate(b) - scoreCandidate(a));
+}
+
+async function fetchWithRedirects(url: URL, init: RequestInit, redirects = 0): Promise<Response> {
+  const response = await fetch(url, {
+    ...init,
+    redirect: 'manual',
+  });
+
+  if (![301, 302, 303, 307, 308].includes(response.status)) {
+    return response;
+  }
+
+  if (redirects >= FAVICON_MAX_REDIRECTS) {
+    return response;
+  }
+
+  const location = response.headers.get('location');
+  if (!location) return response;
+
+  const nextUrl = new URL(location, url);
+  if (!isHttpUrl(nextUrl)) return response;
+
+  return fetchWithRedirects(nextUrl, init, redirects + 1);
+}
+
+async function readResponseBuffer(response: Response, maxBytes: number): Promise<Buffer | null> {
+  if (!response.body) {
+    const arrayBuffer = await response.arrayBuffer();
+    return arrayBuffer.byteLength <= maxBytes ? Buffer.from(arrayBuffer) : null;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+function sniffImageExtension(buffer: Buffer): string | null {
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return '.png';
+  }
+
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return '.jpg';
+  }
+
+  if (buffer.length >= 6) {
+    const signature = buffer.subarray(0, 6).toString('ascii');
+    if (signature === 'GIF87a' || signature === 'GIF89a') return '.gif';
+  }
+
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return '.webp';
+  }
+
+  if (
+    buffer.length >= 4 &&
+    buffer[0] === 0x00 &&
+    buffer[1] === 0x00 &&
+    (buffer[2] === 0x01 || buffer[2] === 0x02) &&
+    buffer[3] === 0x00
+  ) {
+    return '.ico';
+  }
+
+  const prefix = buffer.subarray(0, Math.min(buffer.length, 256)).toString('utf8').trimStart().toLowerCase();
+  if (prefix.startsWith('<svg') || prefix.startsWith('<?xml')) {
+    return '.svg';
+  }
+
+  return null;
+}
+
+function getExtensionFromUrl(url: URL): string | null {
+  const ext = path.extname(url.pathname).toLowerCase();
+  return ext && isAllowedImageExtension(ext) ? ext : null;
+}
+
+async function fetchPageHtml(serviceUrl: URL): Promise<string | null> {
+  const response = await fetchWithRedirects(serviceUrl, {
+    headers: {
+      Accept: 'text/html,application/xhtml+xml',
+      'User-Agent': FAVICON_USER_AGENT,
+    },
+    signal: getTimeoutSignal(),
+  });
+
+  if (!response.ok) return null;
+
+  const contentType = normalizeContentType(response.headers.get('content-type'));
+  if (contentType && !contentType.includes('html')) return null;
+
+  const buffer = await readResponseBuffer(response, FAVICON_PAGE_MAX_BYTES);
+  return buffer?.toString('utf8') ?? null;
+}
+
+async function fetchIconCandidate(candidate: IconCandidate): Promise<{ buffer: Buffer; ext: string } | null> {
+  const response = await fetchWithRedirects(candidate.url, {
+    headers: {
+      Accept: 'image/avif,image/webp,image/svg+xml,image/png,image/*,*/*;q=0.8',
+      'User-Agent': FAVICON_USER_AGENT,
+    },
+    signal: getTimeoutSignal(),
+  });
+
+  if (!response.ok) return null;
+
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > MAX_FILE_SIZE) return null;
+
+  const contentType = normalizeContentType(response.headers.get('content-type'));
+  const extFromContentType = getImageExtensionForContentType(contentType);
+  const extFromUrl = getExtensionFromUrl(candidate.url);
+
+  if (contentType && !isAllowedImageMime(contentType) && contentType !== 'application/octet-stream') {
+    return null;
+  }
+
+  const buffer = await readResponseBuffer(response, MAX_FILE_SIZE);
+  if (!buffer || buffer.length === 0) return null;
+
+  const extFromBytes = sniffImageExtension(buffer);
+  const ext = extFromBytes ?? extFromContentType ?? extFromUrl;
+  if (!ext || !isAllowedImageExtension(ext)) return null;
+
+  return { buffer, ext };
+}
+
+async function findServiceFavicon(serviceUrl: string): Promise<{ buffer: Buffer; ext: string } | null> {
+  const baseUrl = new URL(serviceUrl);
+  if (!isHttpUrl(baseUrl)) return null;
+
+  const fallbackCandidates: IconCandidate[] = [
+    { url: new URL('/apple-touch-icon.png', baseUrl), rel: 'apple-touch-icon', source: 'fallback' },
+    { url: new URL('/favicon.svg', baseUrl), rel: 'icon', source: 'fallback' },
+    { url: new URL('/favicon.png', baseUrl), rel: 'icon', source: 'fallback' },
+    { url: new URL('/favicon.ico', baseUrl), rel: 'icon', source: 'fallback' },
+  ];
+
+  const html = await fetchPageHtml(baseUrl);
+  const htmlCandidates = html ? parseIconCandidates(html, baseUrl) : [];
+  const candidates = dedupeAndSortCandidates([...htmlCandidates, ...fallbackCandidates]);
+
+  for (const candidate of candidates) {
+    const icon = await fetchIconCandidate(candidate);
+    if (icon) return icon;
+  }
+
+  return null;
+}
+
+export async function fetchServiceFavicon(serviceUrl: string, serviceId: string): Promise<string | null> {
+  try {
+    const icon = await findServiceFavicon(serviceUrl);
+    if (!icon) return null;
+
+    return writeIconBuffer(icon.buffer, `${serviceId}${icon.ext}`, serviceId);
+  } catch (error) {
+    if (error instanceof Error && error.name !== 'TimeoutError' && error.name !== 'AbortError') {
+      console.error('Favicon fetch error:', error);
+    }
+    return null;
+  }
+}
+
+export async function fetchProvisionalServiceFavicon(serviceUrl: string): Promise<string | null> {
+  try {
+    const icon = await findServiceFavicon(serviceUrl);
+    if (!icon) return null;
+
+    return writeIconBuffer(icon.buffer, getProvisionalIconFilename(icon.ext));
+  } catch (error) {
+    if (error instanceof Error && error.name !== 'TimeoutError' && error.name !== 'AbortError') {
+      console.error('Favicon fetch error:', error);
+    }
+    return null;
+  }
+}

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -206,7 +206,9 @@ function sniffImageExtension(buffer: Buffer): string | null {
   }
 
   const prefix = buffer.subarray(0, Math.min(buffer.length, 256)).toString('utf8').trimStart().toLowerCase();
-  if (prefix.startsWith('<svg') || prefix.startsWith('<?xml')) {
+  const xmlDeclaration = /^<\?xml\b[^>]*\?>/.exec(prefix);
+  const rootPrefix = xmlDeclaration ? prefix.slice(xmlDeclaration[0].length).trimStart() : prefix;
+  if (rootPrefix.startsWith('<svg')) {
     return '.svg';
   }
 

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -60,7 +60,7 @@ function parseIconCandidates(html: string, baseUrl: URL): IconCandidate[] {
 
     try {
       const url = new URL(href, baseUrl);
-      if (!isHttpUrl(url) || url.origin !== baseUrl.origin) continue;
+      if (!isHttpUrl(url)) continue;
 
       candidates.push({
         url,
@@ -123,25 +123,29 @@ function dedupeAndSortCandidates(candidates: IconCandidate[]): IconCandidate[] {
   return [...byUrl.values()].sort((a, b) => scoreCandidate(b) - scoreCandidate(a));
 }
 
-async function fetchWithRedirects(url: URL, init: RequestInit, redirects = 0): Promise<Response> {
+async function fetchWithRedirects(
+  url: URL,
+  init: RequestInit,
+  redirects = 0
+): Promise<{ response: Response; url: URL }> {
   const response = await fetch(url, {
     ...init,
     redirect: 'manual',
   });
 
   if (![301, 302, 303, 307, 308].includes(response.status)) {
-    return response;
+    return { response, url };
   }
 
   if (redirects >= FAVICON_MAX_REDIRECTS) {
-    return response;
+    return { response, url };
   }
 
   const location = response.headers.get('location');
-  if (!location) return response;
+  if (!location) return { response, url };
 
   const nextUrl = new URL(location, url);
-  if (!isHttpUrl(nextUrl)) return response;
+  if (!isHttpUrl(nextUrl)) return { response, url };
 
   return fetchWithRedirects(nextUrl, init, redirects + 1);
 }
@@ -220,8 +224,8 @@ function getExtensionFromUrl(url: URL): string | null {
   return ext && isAllowedImageExtension(ext) ? ext : null;
 }
 
-async function fetchPageHtml(serviceUrl: URL): Promise<string | null> {
-  const response = await fetchWithRedirects(serviceUrl, {
+async function fetchPageHtml(serviceUrl: URL): Promise<{ html: string; pageUrl: URL } | null> {
+  const { response, url } = await fetchWithRedirects(serviceUrl, {
     headers: {
       Accept: 'text/html,application/xhtml+xml',
       'User-Agent': FAVICON_USER_AGENT,
@@ -235,11 +239,16 @@ async function fetchPageHtml(serviceUrl: URL): Promise<string | null> {
   if (contentType && !contentType.includes('html')) return null;
 
   const buffer = await readResponseBuffer(response, FAVICON_PAGE_MAX_BYTES);
-  return buffer?.toString('utf8') ?? null;
+  if (!buffer) return null;
+
+  return {
+    html: buffer.toString('utf8'),
+    pageUrl: url,
+  };
 }
 
 async function fetchIconCandidate(candidate: IconCandidate): Promise<{ buffer: Buffer; ext: string } | null> {
-  const response = await fetchWithRedirects(candidate.url, {
+  const { response } = await fetchWithRedirects(candidate.url, {
     headers: {
       Accept: 'image/avif,image/webp,image/svg+xml,image/png,image/*,*/*;q=0.8',
       'User-Agent': FAVICON_USER_AGENT,
@@ -274,15 +283,16 @@ async function findServiceFavicon(serviceUrl: string): Promise<{ buffer: Buffer;
   const baseUrl = new URL(serviceUrl);
   if (!isHttpUrl(baseUrl)) return null;
 
+  const page = await fetchPageHtml(baseUrl);
+  const pageUrl = page?.pageUrl ?? baseUrl;
   const fallbackCandidates: IconCandidate[] = [
-    { url: new URL('/apple-touch-icon.png', baseUrl), rel: 'apple-touch-icon', source: 'fallback' },
-    { url: new URL('/favicon.svg', baseUrl), rel: 'icon', source: 'fallback' },
-    { url: new URL('/favicon.png', baseUrl), rel: 'icon', source: 'fallback' },
-    { url: new URL('/favicon.ico', baseUrl), rel: 'icon', source: 'fallback' },
+    { url: new URL('/apple-touch-icon.png', pageUrl), rel: 'apple-touch-icon', source: 'fallback' },
+    { url: new URL('/favicon.svg', pageUrl), rel: 'icon', source: 'fallback' },
+    { url: new URL('/favicon.png', pageUrl), rel: 'icon', source: 'fallback' },
+    { url: new URL('/favicon.ico', pageUrl), rel: 'icon', source: 'fallback' },
   ];
 
-  const html = await fetchPageHtml(baseUrl);
-  const htmlCandidates = html ? parseIconCandidates(html, baseUrl) : [];
+  const htmlCandidates = page ? parseIconCandidates(page.html, pageUrl) : [];
   const candidates = dedupeAndSortCandidates([...htmlCandidates, ...fallbackCandidates]);
 
   for (const candidate of candidates) {

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -2,8 +2,8 @@ import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { isAllowedImageExtension } from './image-constants';
+import { getIconsDir } from './paths';
 
-const ICONS_DIR = path.join(process.cwd(), 'data', 'icons');
 const APP_LOGO_BASENAME = 'app-logo';
 const PROVISIONAL_ICON_BASENAME_PREFIX = '__tmp-favicon-';
 
@@ -13,7 +13,7 @@ interface IconFileBackup {
 }
 
 async function getIconFilesForBaseName(baseName: string): Promise<string[]> {
-  const files = await fs.readdir(ICONS_DIR).catch(() => []);
+  const files = await fs.readdir(getIconsDir()).catch(() => []);
 
   return files.filter((file) => path.parse(file).name === baseName);
 }
@@ -28,7 +28,7 @@ export async function deleteServiceIcon(serviceId: string): Promise<void> {
 
     // Delete each found icon file
     for (const file of iconFiles) {
-      const filePath = path.join(ICONS_DIR, file);
+      const filePath = path.join(getIconsDir(), file);
       await fs.unlink(filePath);
       console.log(`Deleted icon: ${file}`);
     }
@@ -63,7 +63,7 @@ export function isValidImageExtension(filename: string): boolean {
  * Gets the full filesystem path for an icon
  */
 export function getIconFilePath(filename: string): string {
-  return path.join(ICONS_DIR, filename);
+  return path.join(getIconsDir(), filename);
 }
 
 /**
@@ -113,7 +113,7 @@ export async function restoreServiceIconFiles(
   serviceId: string,
   backups: IconFileBackup[]
 ): Promise<void> {
-  await fs.mkdir(ICONS_DIR, { recursive: true });
+  await fs.mkdir(getIconsDir(), { recursive: true });
 
   const currentFiles = await getIconFilesForBaseName(serviceId);
   await Promise.all(currentFiles.map((filename) => (
@@ -154,7 +154,7 @@ export async function promoteProvisionalIcon(iconPath: string, serviceId: string
  * Deletes a single icon file by stored config path (e.g., "icons/foo.png").
  */
 export async function deleteIconFile(iconPath: string): Promise<void> {
-  const filePath = path.join(ICONS_DIR, path.basename(iconPath));
+  const filePath = path.join(getIconsDir(), path.basename(iconPath));
 
   await fs.unlink(filePath).catch(() => {});
 }
@@ -163,7 +163,7 @@ export async function deleteIconFile(iconPath: string): Promise<void> {
  * Deletes the stored app logo file at the given config path (e.g., "icons/foo.png").
  */
 export async function deleteAppLogo(iconPath: string): Promise<void> {
-  const filePath = path.join(ICONS_DIR, path.basename(iconPath));
+  const filePath = path.join(getIconsDir(), path.basename(iconPath));
   try {
     await fs.unlink(filePath).catch(() => {});
   } catch (error) {

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { isAllowedImageExtension } from './image-constants';
 
 const ICONS_DIR = path.join(process.cwd(), 'data', 'icons');
 const APP_LOGO_BASENAME = 'app-logo';
+const PROVISIONAL_ICON_BASENAME_PREFIX = '__tmp-favicon-';
 
 /**
  * Deletes all icon files for a given service ID
@@ -62,6 +64,78 @@ export function isValidImageExtension(filename: string): boolean {
  */
 export function getIconFilePath(filename: string): string {
   return path.join(ICONS_DIR, filename);
+}
+
+/**
+ * Writes an icon buffer atomically and removes stale files for the same logical icon name.
+ */
+export async function writeIconBuffer(
+  buffer: Buffer,
+  filename: string,
+  baseNameForCleanup?: string
+): Promise<string> {
+  const filePath = getIconFilePath(filename);
+  const iconsDir = path.dirname(filePath);
+  const tempPath = path.join(iconsDir, `${filename}.tmp-${randomUUID()}`);
+
+  await fs.mkdir(iconsDir, { recursive: true });
+
+  const existingIcons = baseNameForCleanup ? await fs.readdir(iconsDir).catch(() => []) : [];
+  const oldFiles = existingIcons.filter((file) => (
+    path.parse(file).name === baseNameForCleanup && file !== filename
+  ));
+
+  try {
+    await fs.writeFile(tempPath, buffer);
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.unlink(tempPath).catch(() => {});
+    throw error;
+  }
+
+  for (const oldFile of oldFiles) {
+    await fs.unlink(path.join(iconsDir, oldFile)).catch(() => {});
+  }
+
+  return `icons/${filename}`;
+}
+
+export function getProvisionalIconFilename(ext: string): string {
+  return `${PROVISIONAL_ICON_BASENAME_PREFIX}${randomUUID()}${ext}`;
+}
+
+export function isProvisionalIconPath(iconPath: string): boolean {
+  const filename = path.basename(iconPath);
+
+  return (
+    iconPath === `icons/${filename}` &&
+    path.parse(filename).name.startsWith(PROVISIONAL_ICON_BASENAME_PREFIX) &&
+    isValidImageExtension(filename)
+  );
+}
+
+export async function promoteProvisionalIcon(iconPath: string, serviceId: string): Promise<string> {
+  if (!isProvisionalIconPath(iconPath)) {
+    throw new Error('Only provisional icons can be promoted');
+  }
+
+  const filename = path.basename(iconPath);
+  const ext = path.extname(filename).toLowerCase();
+  const buffer = await fs.readFile(getIconFilePath(filename));
+  const promotedPath = await writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
+
+  await deleteIconFile(iconPath);
+
+  return promotedPath;
+}
+
+/**
+ * Deletes a single icon file by stored config path (e.g., "icons/foo.png").
+ */
+export async function deleteIconFile(iconPath: string): Promise<void> {
+  const filePath = path.join(ICONS_DIR, path.basename(iconPath));
+
+  await fs.unlink(filePath).catch(() => {});
 }
 
 /**

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -7,19 +7,24 @@ const ICONS_DIR = path.join(process.cwd(), 'data', 'icons');
 const APP_LOGO_BASENAME = 'app-logo';
 const PROVISIONAL_ICON_BASENAME_PREFIX = '__tmp-favicon-';
 
+interface IconFileBackup {
+  filename: string;
+  buffer: Buffer;
+}
+
+async function getIconFilesForBaseName(baseName: string): Promise<string[]> {
+  const files = await fs.readdir(ICONS_DIR).catch(() => []);
+
+  return files.filter((file) => path.parse(file).name === baseName);
+}
+
 /**
  * Deletes all icon files for a given service ID
  * Checks all possible extensions since we don't know which one was uploaded
  */
 export async function deleteServiceIcon(serviceId: string): Promise<void> {
   try {
-    const files = await fs.readdir(ICONS_DIR);
-
-    // Find all files that start with the serviceId
-    const iconFiles = files.filter(file => {
-      const nameWithoutExt = path.parse(file).name;
-      return nameWithoutExt === serviceId;
-    });
+    const iconFiles = await getIconFilesForBaseName(serviceId);
 
     // Delete each found icon file
     for (const file of iconFiles) {
@@ -38,12 +43,7 @@ export async function deleteServiceIcon(serviceId: string): Promise<void> {
  */
 export async function getServiceIconPath(serviceId: string): Promise<string | null> {
   try {
-    const files = await fs.readdir(ICONS_DIR);
-
-    const iconFile = files.find(file => {
-      const nameWithoutExt = path.parse(file).name;
-      return nameWithoutExt === serviceId;
-    });
+    const iconFile = (await getIconFilesForBaseName(serviceId))[0];
 
     return iconFile ? `icons/${iconFile}` : null;
   } catch (error) {
@@ -100,6 +100,31 @@ export async function writeIconBuffer(
   return `icons/${filename}`;
 }
 
+export async function backupServiceIconFiles(serviceId: string): Promise<IconFileBackup[]> {
+  const files = await getIconFilesForBaseName(serviceId);
+
+  return Promise.all(files.map(async (filename) => ({
+    filename,
+    buffer: await fs.readFile(getIconFilePath(filename)),
+  })));
+}
+
+export async function restoreServiceIconFiles(
+  serviceId: string,
+  backups: IconFileBackup[]
+): Promise<void> {
+  await fs.mkdir(ICONS_DIR, { recursive: true });
+
+  const currentFiles = await getIconFilesForBaseName(serviceId);
+  await Promise.all(currentFiles.map((filename) => (
+    fs.unlink(getIconFilePath(filename)).catch(() => {})
+  )));
+
+  await Promise.all(backups.map((backup) => (
+    fs.writeFile(getIconFilePath(backup.filename), backup.buffer)
+  )));
+}
+
 export function getProvisionalIconFilename(ext: string): string {
   return `${PROVISIONAL_ICON_BASENAME_PREFIX}${randomUUID()}${ext}`;
 }
@@ -122,11 +147,7 @@ export async function promoteProvisionalIcon(iconPath: string, serviceId: string
   const filename = path.basename(iconPath);
   const ext = path.extname(filename).toLowerCase();
   const buffer = await fs.readFile(getIconFilePath(filename));
-  const promotedPath = await writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
-
-  await deleteIconFile(iconPath);
-
-  return promotedPath;
+  return writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
 }
 
 /**

--- a/lib/image-constants.ts
+++ b/lib/image-constants.ts
@@ -7,13 +7,19 @@ const IMAGE_TYPE_MAP = {
   '.svg': 'image/svg+xml',
   '.webp': 'image/webp',
   '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
 } as const;
+const ADDITIONAL_IMAGE_MIME_TYPES = ['image/vnd.microsoft.icon'] as const;
 
 type ImageExtension = keyof typeof IMAGE_TYPE_MAP;
-type ImageMimeType = (typeof IMAGE_TYPE_MAP)[ImageExtension];
+type ImageMimeType =
+  | (typeof IMAGE_TYPE_MAP)[ImageExtension]
+  | (typeof ADDITIONAL_IMAGE_MIME_TYPES)[number];
 
 const IMAGE_EXTENSIONS = Object.keys(IMAGE_TYPE_MAP) as ImageExtension[];
-const IMAGE_MIME_TYPES = Object.values(IMAGE_TYPE_MAP) as ImageMimeType[];
+const IMAGE_MIME_TYPES = [
+  ...new Set([...Object.values(IMAGE_TYPE_MAP), ...ADDITIONAL_IMAGE_MIME_TYPES]),
+] as ImageMimeType[];
 
 const IMAGE_ACCEPT = IMAGE_MIME_TYPES.join(',');
 const IMAGE_TYPE_LABEL = IMAGE_EXTENSIONS.map(ext => ext.slice(1).toUpperCase()).join(', ');
@@ -37,6 +43,17 @@ export function isAllowedImageMime(value: string): value is ImageMimeType {
 export function getImageContentType(value: string): ImageMimeType | null {
   const ext = extractExtension(value);
   return (IMAGE_TYPE_MAP as Record<string, ImageMimeType>)[ext] ?? null;
+}
+
+export function getImageExtensionForContentType(value: string): ImageExtension | null {
+  const contentType = value.toLowerCase().split(';')[0]?.trim();
+
+  if (contentType === 'image/vnd.microsoft.icon') {
+    return '.ico';
+  }
+
+  const entry = Object.entries(IMAGE_TYPE_MAP).find(([, mime]) => mime === contentType);
+  return entry ? (entry[0] as ImageExtension) : null;
 }
 
 export {

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+
+export const DATA_DIR_ENV = 'CRAPDASH_DATA_DIR';
+
+export function getDataDir(): string {
+  const configuredDataDir = process.env[DATA_DIR_ENV];
+
+  return configuredDataDir ? path.resolve(configuredDataDir) : path.join(process.cwd(), 'data');
+}
+
+export function getConfigPath(): string {
+  return path.join(getDataDir(), 'config.json');
+}
+
+export function getConfigLockPath(): string {
+  return `${getConfigPath()}.lock`;
+}
+
+export function getIconsDir(): string {
+  return path.join(getDataDir(), 'icons');
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -72,7 +72,9 @@ export interface ImportConfigResult {
 export type CategoryFormData = Omit<Category, 'id'>;
 export type CategoryCreateData = Category;
 export type ServiceFormData = Omit<Service, 'id'>;
-export type ServiceCreateData = Service;
+export type ServiceCreateData = Service & {
+  fetchFavicon?: boolean;
+};
 
 export interface ValidationError {
   field: string;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "vitest run",
     "tag:version": "v=$(node -p \"require('./package.json').version\") && git tag v$v && git push origin v$v"
   },
   "dependencies": {
@@ -53,6 +54,7 @@
     "eslint-config-next": "16.2.4",
     "shadcn": "^4.6.0",
     "tailwindcss": "^4.2.4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crapdash",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@11.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@types/node@25.6.0)(msw@2.14.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
 
 packages:
 
@@ -352,14 +355,23 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@eslint-community/eslint-utils@4.9.0':
     resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
@@ -690,6 +702,12 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -787,6 +805,9 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1478,6 +1499,104 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -1487,6 +1606,9 @@ packages:
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1588,6 +1710,12 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1780,6 +1908,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@4.1.5':
+    resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@4.1.5':
+    resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.5':
+    resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
+
+  '@vitest/runner@4.1.5':
+    resolution: {integrity: sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==}
+
+  '@vitest/snapshot@4.1.5':
+    resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
+
+  '@vitest/spy@4.1.5':
+    resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
+
+  '@vitest/utils@4.1.5':
+    resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1867,6 +2024,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -1950,6 +2111,10 @@ packages:
 
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2214,6 +2379,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2362,6 +2530,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2385,6 +2556,10 @@ packages:
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.4.1:
     resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
@@ -2510,6 +2685,11 @@ packages:
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
     engines: {node: '>=14.14'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -3245,6 +3425,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3327,16 +3510,15 @@ packages:
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -3356,6 +3538,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.13:
+    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -3510,6 +3696,11 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3606,6 +3797,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3633,9 +3827,15 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -3748,9 +3948,24 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.0.29:
     resolution: {integrity: sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==}
@@ -3903,6 +4118,90 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.5:
+    resolution: {integrity: sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.5
+      '@vitest/browser-preview': 4.1.5
+      '@vitest/browser-webdriverio': 4.1.5
+      '@vitest/coverage-istanbul': 4.1.5
+      '@vitest/coverage-v8': 4.1.5
+      '@vitest/ui': 4.1.5
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -3934,6 +4233,11 @@ packages:
   which@4.0.0:
     resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
     engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4303,9 +4607,20 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -4315,6 +4630,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4616,6 +4936,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@next/env@16.2.4': {}
 
   '@next/eslint-plugin-next@16.2.4':
@@ -4678,6 +5005,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5426,11 +5755,64 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
+
   '@rtsao/scc@1.1.0': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -5515,6 +5897,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -5692,6 +6081,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@4.1.5':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.5
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.2(@types/node@25.6.0)(typescript@5.9.3)
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.5':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.5':
+    dependencies:
+      '@vitest/utils': 4.1.5
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/utils': 4.1.5
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.5': {}
+
+  '@vitest/utils@4.1.5':
+    dependencies:
+      '@vitest/pretty-format': 4.1.5
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -5806,6 +6237,8 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   ast-types@0.16.1:
@@ -5893,6 +6326,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001770: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6184,6 +6619,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -6416,6 +6853,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -6452,6 +6893,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
@@ -6529,10 +6972,6 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
-    optionalDependencies:
-      picomatch: 4.0.3
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -6609,6 +7048,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -7268,6 +7710,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7359,11 +7803,11 @@ snapshots:
 
   path-to-regexp@8.4.2: {}
 
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
-
-  picomatch@4.0.3: {}
 
   picomatch@4.0.4: {}
 
@@ -7377,6 +7821,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.13:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -7590,6 +8040,27 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rolldown@1.0.0-rc.17:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -7793,6 +8264,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7810,7 +8283,11 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -7930,10 +8407,21 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.1.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.29: {}
 
@@ -8113,6 +8601,45 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 25.6.0
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.5(@types/node@25.6.0)(msw@2.14.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(msw@2.14.2(@types/node@25.6.0)(typescript@5.9.3))(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.6.0
+    transitivePeerDependencies:
+      - msw
+
   w3c-keyname@2.2.8: {}
 
   web-streams-polyfill@3.3.3: {}
@@ -8165,6 +8692,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.5
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -1,0 +1,108 @@
+import { chmod, readFile, stat, writeFile } from 'fs/promises';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanupFetchedServiceIcon, createService, updateService } from '@/lib/actions';
+import { getConfigPath, getDataDir, getIconsDir } from '@/lib/paths';
+import { ICON_TYPES, type DashboardConfig } from '@/lib/types';
+import { createTestDataDir, removeTestDataDir } from './test-data-dir';
+
+let rootDir: string;
+
+async function writeConfig(config: DashboardConfig): Promise<void> {
+  await writeFile(getConfigPath(), JSON.stringify(config, null, 2));
+}
+
+async function writeIcon(filename: string, content: string): Promise<void> {
+  await writeFile(path.join(getIconsDir(), filename), content);
+}
+
+async function fileExists(filename: string): Promise<boolean> {
+  return stat(path.join(getIconsDir(), filename))
+    .then(() => true)
+    .catch(() => false);
+}
+
+describe('service icon actions', () => {
+  beforeEach(async () => {
+    rootDir = await createTestDataDir('actions');
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    await chmod(getDataDir(), 0o755).catch(() => {});
+    await removeTestDataDir(rootDir);
+  });
+
+  it('refuses to clean up persisted service icon paths', async () => {
+    await writeIcon('grafana.png', 'persisted icon');
+    const formData = new FormData();
+    formData.append('iconPath', 'icons/grafana.png');
+
+    const result = await cleanupFetchedServiceIcon(formData);
+
+    expect(result.success).toBe(false);
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('persisted icon');
+  });
+
+  it('promotes a provisional icon when creating a service', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [],
+    });
+    await writeIcon('__tmp-favicon-preview.png', 'fetched icon');
+
+    const result = await createService({
+      id: 'grafana',
+      name: 'Grafana',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/__tmp-favicon-preview.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' });
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('fetched icon');
+
+    const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
+    expect(savedConfig.services[0]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' });
+  });
+
+  it('restores previous icon files when update config persistence fails after promotion', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' },
+        active: true,
+      }],
+    });
+    await writeIcon('grafana.svg', 'old icon');
+    await writeIcon('__tmp-favicon-preview.ico', 'new icon');
+    await chmod(getDataDir(), 0o555);
+
+    const result = await updateService('grafana', {
+      name: 'Grafana',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/__tmp-favicon-preview.ico' },
+      active: true,
+    });
+
+    expect(result.success).toBe(false);
+    expect(await fileExists('grafana.ico')).toBe(false);
+    await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('old icon');
+
+    await chmod(getDataDir(), 0o755);
+    const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
+    expect(savedConfig.services[0]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' });
+  });
+});

--- a/tests/lib/config-import.test.ts
+++ b/tests/lib/config-import.test.ts
@@ -1,0 +1,84 @@
+import { writeFile } from 'fs/promises';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { collectConfigImportWarnings } from '@/lib/config-import';
+import { getIconsDir } from '@/lib/paths';
+import { ICON_TYPES, type DashboardConfig } from '@/lib/types';
+import { createTestDataDir, removeTestDataDir } from './test-data-dir';
+
+let rootDir: string;
+
+describe('collectConfigImportWarnings', () => {
+  beforeEach(async () => {
+    rootDir = await createTestDataDir('config-import');
+  });
+
+  afterEach(async () => {
+    await removeTestDataDir(rootDir);
+  });
+
+  it('warns for missing referenced image files', async () => {
+    const config: DashboardConfig = {
+      categories: [],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+        active: true,
+      }],
+    };
+
+    await expect(collectConfigImportWarnings(config)).resolves.toEqual([
+      {
+        field: 'services.0.icon.value',
+        message: 'Icon file "icons/grafana.png" was not found under data/icons.',
+      },
+    ]);
+  });
+
+  it('warns for unsupported image extensions', async () => {
+    await writeFile(path.join(getIconsDir(), 'grafana.bmp'), 'bitmap');
+    const config: DashboardConfig = {
+      categories: [],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.bmp' },
+        active: true,
+      }],
+    };
+
+    await expect(collectConfigImportWarnings(config)).resolves.toEqual([
+      {
+        field: 'services.0.icon.value',
+        message: 'Icon "icons/grafana.bmp" uses an unsupported extension and may not be served correctly.',
+      },
+    ]);
+  });
+
+  it('does not warn for existing supported image references', async () => {
+    await writeFile(path.join(getIconsDir(), 'app-logo.png'), 'logo');
+    await writeFile(path.join(getIconsDir(), 'grafana.svg'), '<svg />');
+    const config: DashboardConfig = {
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/app-logo.png' },
+      categories: [],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' },
+        active: true,
+      }],
+    };
+
+    await expect(collectConfigImportWarnings(config)).resolves.toEqual([]);
+  });
+});

--- a/tests/lib/favicon.test.ts
+++ b/tests/lib/favicon.test.ts
@@ -1,0 +1,69 @@
+import { readdir, readFile } from 'fs/promises';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchServiceFavicon } from '@/lib/favicon';
+import { getIconsDir } from '@/lib/paths';
+import { createTestDataDir, removeTestDataDir } from './test-data-dir';
+
+let rootDir: string;
+
+function response(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, init);
+}
+
+describe('favicon fetching', () => {
+  beforeEach(async () => {
+    rootDir = await createTestDataDir('favicon');
+  });
+
+  afterEach(async () => {
+    await removeTestDataDir(rootDir);
+  });
+
+  it('rejects non-SVG XML payloads when content type is generic', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('<link rel="icon" href="/feed.xml" type="application/octet-stream">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      if (url === 'https://example.com/feed.xml') {
+        return response('<?xml version="1.0"?><rss><channel /></rss>', {
+          headers: { 'content-type': 'application/octet-stream' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBeNull();
+    await expect(readdir(getIconsDir())).resolves.toEqual([]);
+  });
+
+  it('accepts SVG payloads after an XML declaration', async () => {
+    const svg = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" />';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('<link rel="icon" href="/favicon.xml" type="application/octet-stream">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      if (url === 'https://example.com/favicon.xml') {
+        return response(svg, {
+          headers: { 'content-type': 'application/octet-stream' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.svg');
+    await expect(readFile(path.join(getIconsDir(), 'example.svg'), 'utf-8')).resolves.toBe(svg);
+  });
+});

--- a/tests/lib/favicon.test.ts
+++ b/tests/lib/favicon.test.ts
@@ -66,4 +66,59 @@ describe('favicon fetching', () => {
     await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.svg');
     await expect(readFile(path.join(getIconsDir(), 'example.svg'), 'utf-8')).resolves.toBe(svg);
   });
+
+  it('resolves relative icon URLs against the final page URL after redirects', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('', {
+          status: 301,
+          headers: { location: 'https://www.example.com/dashboard/' },
+        });
+      }
+
+      if (url === 'https://www.example.com/dashboard/') {
+        return response('<link rel="icon" href="assets/icon.png" type="image/png">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      if (url === 'https://www.example.com/dashboard/assets/icon.png') {
+        return new Response(png, {
+          headers: { 'content-type': 'image/png' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.png');
+    await expect(readFile(path.join(getIconsDir(), 'example.png'))).resolves.toEqual(png);
+  });
+
+  it('accepts cross-origin icon URLs declared by the page', async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('<link rel="icon" href="https://cdn.example.com/favicon.png" type="image/png">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      if (url === 'https://cdn.example.com/favicon.png') {
+        return new Response(png, {
+          headers: { 'content-type': 'image/png' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.png');
+    await expect(readFile(path.join(getIconsDir(), 'example.png'))).resolves.toEqual(png);
+  });
 });

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -1,0 +1,62 @@
+import { readFile, readdir, writeFile } from 'fs/promises';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  backupServiceIconFiles,
+  isProvisionalIconPath,
+  promoteProvisionalIcon,
+  restoreServiceIconFiles,
+} from '@/lib/file-utils';
+import { getIconsDir } from '@/lib/paths';
+import { createTestDataDir, removeTestDataDir } from './test-data-dir';
+
+let rootDir: string;
+
+async function writeIcon(filename: string, content: string): Promise<void> {
+  await writeFile(path.join(getIconsDir(), filename), content);
+}
+
+describe('file-utils icon persistence', () => {
+  beforeEach(async () => {
+    rootDir = await createTestDataDir('file-utils');
+  });
+
+  afterEach(async () => {
+    await removeTestDataDir(rootDir);
+  });
+
+  it('recognizes only provisional icon paths as provisional', () => {
+    expect(isProvisionalIconPath('icons/__tmp-favicon-abc.png')).toBe(true);
+    expect(isProvisionalIconPath('icons/service.png')).toBe(false);
+    expect(isProvisionalIconPath('../icons/__tmp-favicon-abc.png')).toBe(false);
+  });
+
+  it('promotes a provisional icon to the service basename', async () => {
+    await writeIcon('__tmp-favicon-preview.png', 'new icon');
+    await writeIcon('grafana.svg', 'old icon');
+    await writeIcon('other.svg', 'other icon');
+
+    const promotedPath = await promoteProvisionalIcon('icons/__tmp-favicon-preview.png', 'grafana');
+    const files = await readdir(getIconsDir());
+
+    expect(promotedPath).toBe('icons/grafana.png');
+    expect(files).toEqual(expect.arrayContaining(['__tmp-favicon-preview.png', 'grafana.png', 'other.svg']));
+    expect(files).not.toContain('grafana.svg');
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('new icon');
+    await expect(readFile(path.join(getIconsDir(), 'other.svg'), 'utf-8')).resolves.toBe('other icon');
+  });
+
+  it('restores service icon files from backup after replacement', async () => {
+    await writeIcon('grafana.svg', 'old icon');
+    await writeIcon('__tmp-favicon-preview.ico', 'new icon');
+
+    const backup = await backupServiceIconFiles('grafana');
+    await promoteProvisionalIcon('icons/__tmp-favicon-preview.ico', 'grafana');
+    await restoreServiceIconFiles('grafana', backup);
+    const files = await readdir(getIconsDir());
+
+    expect(files).toEqual(expect.arrayContaining(['__tmp-favicon-preview.ico', 'grafana.svg']));
+    expect(files).not.toContain('grafana.ico');
+    await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('old icon');
+  });
+});

--- a/tests/lib/preferences.test.ts
+++ b/tests/lib/preferences.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { RANDOM_APPEARANCE } from '@/lib/appearance-config';
+import { parsePreferences } from '@/lib/preferences';
+import { LAYOUTS } from '@/lib/types';
+
+function encodePreferenceCookie(value: unknown): string {
+  return encodeURIComponent(JSON.stringify(value));
+}
+
+describe('parsePreferences', () => {
+  it('returns an empty object for missing or malformed cookies', () => {
+    expect(parsePreferences(undefined)).toEqual({});
+    expect(parsePreferences('%')).toEqual({});
+    expect(parsePreferences(encodeURIComponent('{bad json'))).toEqual({});
+  });
+
+  it('accepts valid persisted preference values', () => {
+    expect(parsePreferences(encodePreferenceCookie({
+      layout: LAYOUTS.COLUMNS,
+      expandOnHover: true,
+      appearance: 'mono',
+    }))).toEqual({
+      layout: LAYOUTS.COLUMNS,
+      expandOnHover: true,
+      appearance: 'mono',
+    });
+  });
+
+  it('ignores invalid values while preserving valid fields', () => {
+    expect(parsePreferences(encodePreferenceCookie({
+      layout: 'grid',
+      expandOnHover: false,
+      appearance: 'unknown',
+    }))).toEqual({
+      expandOnHover: false,
+    });
+  });
+
+  it('accepts the random appearance setting', () => {
+    expect(parsePreferences(encodePreferenceCookie({
+      appearance: RANDOM_APPEARANCE,
+    }))).toEqual({
+      appearance: RANDOM_APPEARANCE,
+    });
+  });
+});

--- a/tests/lib/test-data-dir.ts
+++ b/tests/lib/test-data-dir.ts
@@ -1,0 +1,18 @@
+import { mkdtemp, mkdir, rm } from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { DATA_DIR_ENV } from '@/lib/paths';
+
+export async function createTestDataDir(name: string): Promise<string> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), `crapdash-${name}-`));
+  const dataDir = path.join(rootDir, 'data');
+
+  await mkdir(path.join(dataDir, 'icons'), { recursive: true });
+  process.env[DATA_DIR_ENV] = dataDir;
+
+  return rootDir;
+}
+
+export async function removeTestDataDir(rootDir: string): Promise<void> {
+  await rm(rootDir, { recursive: true, force: true });
+}

--- a/tests/lib/utils.test.ts
+++ b/tests/lib/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_APP_TITLE } from '@/lib/types';
+import { getAppTitle, getConfigExportFilename, slugify } from '@/lib/utils';
+
+describe('utility helpers', () => {
+  it('slugifies service and category names', () => {
+    expect(slugify(' Grafana Cloud / Prod! ')).toBe('grafana-cloud-prod');
+    expect(slugify('Already---Slugged')).toBe('already-slugged');
+  });
+
+  it('falls back to the default app title for blank values', () => {
+    expect(getAppTitle('My Dashboard')).toBe('My Dashboard');
+    expect(getAppTitle('   ')).toBe(DEFAULT_APP_TITLE);
+    expect(getAppTitle()).toBe(DEFAULT_APP_TITLE);
+  });
+
+  it('formats config export filenames with the ISO calendar date', () => {
+    const date = new Date('2026-05-03T23:59:59.000Z');
+
+    expect(getConfigExportFilename(date)).toBe('crapdash-config-2026-05-03.json');
+  });
+});

--- a/tests/lib/validations.test.ts
+++ b/tests/lib/validations.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { ICON_TYPES } from '@/lib/types';
+import { dashboardConfigImportSchema } from '@/lib/validations';
+
+describe('dashboard config import validation', () => {
+  it('defaults imported services to active', () => {
+    const result = dashboardConfigImportSchema.parse({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+      }],
+    });
+
+    expect(result.services[0]?.active).toBe(true);
+  });
+
+  it('rejects duplicate category IDs', () => {
+    const result = dashboardConfigImportSchema.safeParse({
+      categories: [
+        { id: 'infra', name: 'Infrastructure' },
+        { id: 'infra', name: 'Duplicate' },
+      ],
+      services: [],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: 'Duplicate category id "infra"',
+        path: ['categories', 1, 'id'],
+      }),
+    ]));
+  });
+
+  it('rejects duplicate service IDs', () => {
+    const result = dashboardConfigImportSchema.safeParse({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [
+        {
+          id: 'grafana',
+          name: 'Grafana',
+          description: 'Dashboards',
+          url: 'https://grafana.example.com',
+          categoryId: 'infra',
+          active: true,
+        },
+        {
+          id: 'grafana',
+          name: 'Grafana duplicate',
+          description: 'Dashboards',
+          url: 'https://grafana-duplicate.example.com',
+          categoryId: 'infra',
+          active: true,
+        },
+      ],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: 'Duplicate service id "grafana"',
+        path: ['services', 1, 'id'],
+      }),
+    ]));
+  });
+
+  it('rejects services that reference unknown categories', () => {
+    const result = dashboardConfigImportSchema.safeParse({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'missing',
+        active: true,
+      }],
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: 'Service references unknown category "missing"',
+        path: ['services', 0, 'categoryId'],
+      }),
+    ]));
+  });
+
+  it('rejects image icons for categories', () => {
+    const result = dashboardConfigImportSchema.safeParse({
+      categories: [{
+        id: 'infra',
+        name: 'Infrastructure',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/infra.png' },
+      }],
+      services: [],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('normalizes Lucide icon names case-insensitively', () => {
+    const result = dashboardConfigImportSchema.parse({
+      categories: [{
+        id: 'infra',
+        name: 'Infrastructure',
+        icon: { type: ICON_TYPES.ICON, value: 'settings' },
+      }],
+      services: [],
+    });
+
+    expect(result.categories[0]?.icon).toEqual({ type: ICON_TYPES.ICON, value: 'Settings' });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,10 @@
+import { afterEach, vi } from 'vitest';
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+afterEach(() => {
+  delete process.env.CRAPDASH_DATA_DIR;
+  vi.restoreAllMocks();
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname),
+    },
+  },
+  test: {
+    environment: 'node',
+    setupFiles: ['./tests/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- Auto-fetch favicons from service URLs when creating new services
- Add “Fetch favicon” action to the service icon picker
- Add support for `.ico` image files and common favicon MIME types
- Keep fetched icons aligned with the saved service slug
- Add test suite and corresponding CI runner
