### PR TITLE
Add service metadata autofill

### DIFF
--- a/components/admin/icon-pickers/icon-upload.tsx
+++ b/components/admin/icon-pickers/icon-upload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useMemo, useEffect } from 'react';
-import { Globe, Upload, X, ImageIcon } from 'lucide-react';
+import { RefreshCw, Upload, X, ImageIcon } from 'lucide-react';
 import Image from 'next/image';
 
 import { Button } from '@/components/ui/button';
@@ -147,7 +147,7 @@ export function IconUpload({
                   size="sm"
                   onClick={openFilePicker}
                 >
-                  <Upload className="w-4 h-4" />
+                  <Upload data-icon="inline-start" />
                   Upload file
                 </Button>
 
@@ -159,7 +159,7 @@ export function IconUpload({
                     onClick={onFetchFromUrl}
                     disabled={fetchDisabled || isFetching}
                   >
-                    <Globe className="w-4 h-4" />
+                    <RefreshCw data-icon="inline-start" className={cn(isFetching && 'animate-spin')} />
                     {isFetching ? 'Fetching...' : 'Fetch favicon'}
                   </Button>
                 )}
@@ -171,7 +171,7 @@ export function IconUpload({
                     size="sm"
                     onClick={handleClear}
                   >
-                    <X className="w-4 h-4" />
+                    <X data-icon="inline-start" />
                     Remove
                   </Button>
                 )}

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,8 +19,13 @@ import { Field, FieldLabel, FieldError, FieldDescription } from '@/components/ui
 import { IconPicker } from '../icon-pickers/icon-picker';
 import { CategoryIcon } from '@/components/common/icons/category-icon';
 import { resolveLucideIconName } from '@/lib/lucide-icons';
-import { cleanupFetchedServiceIcon, createService, fetchServiceIcon, updateService, uploadServiceIcon } from '@/lib/actions';
-import { slugify } from '@/lib/utils';
+import { cleanupFetchedServiceIcon, createService, fetchServiceIcon, fetchServiceMetadata, updateService, uploadServiceIcon } from '@/lib/actions';
+import {
+  SERVICE_METADATA_APPLY_MODES,
+  getServiceMetadataDraftUpdates,
+  type ServiceMetadataApplyMode,
+} from '@/lib/service-metadata-apply';
+import { cn, slugify } from '@/lib/utils';
 import { ICON_TYPES, type Category, type IconConfig, type Service } from '@/lib/types';
 
 interface ServiceFormProps {
@@ -33,6 +39,11 @@ interface ServiceFormProps {
 interface FetchedIconRef {
   serviceId: string;
   iconPath: string;
+}
+
+interface FetchedServiceMetadata {
+  title?: string;
+  description?: string;
 }
 
 function parseServiceUrl(value: string): string | null {
@@ -67,11 +78,20 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFetchingIcon, setIsFetchingIcon] = useState(false);
+  const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
   const [iconVersion, setIconVersion] = useState(0);
   const [iconControl, setIconControl] = useState<'auto' | 'manual'>(service ? 'manual' : 'auto');
   const urlRef = useRef(url);
+  const nameRef = useRef(name);
+  const descriptionRef = useRef(description);
+  const hasUserEditedNameRef = useRef(!!service);
+  const hasUserEditedDescriptionRef = useRef(!!service);
   const lastAutoFetchKeyRef = useRef<string | null>(null);
+  const lastAutoMetadataFetchKeyRef = useRef<string | null>(null);
   const autoFetchRequestRef = useRef(0);
+  const metadataFetchRequestRef = useRef(0);
+  const autoFetchTimeoutRef = useRef<number | null>(null);
+  const metadataFetchTimeoutRef = useRef<number | null>(null);
   const provisionalIconRef = useRef<FetchedIconRef | null>(null);
 
   // Generate slug from name for new services
@@ -84,7 +104,84 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     urlRef.current = url;
   }, [url]);
 
+  useEffect(() => {
+    nameRef.current = name;
+  }, [name]);
+
+  useEffect(() => {
+    descriptionRef.current = description;
+  }, [description]);
+
   const getLatestValidServiceUrl = useCallback((): string | null => parseServiceUrl(urlRef.current), []);
+
+  const hasFillableMetadataFields = useCallback((): boolean => (
+    !hasUserEditedNameRef.current ||
+    nameRef.current.trim().length === 0 ||
+    !hasUserEditedDescriptionRef.current ||
+    descriptionRef.current.trim().length === 0
+  ), []);
+
+  const clearAutoIconFetchTimeout = useCallback(() => {
+    if (autoFetchTimeoutRef.current === null) return;
+    window.clearTimeout(autoFetchTimeoutRef.current);
+    autoFetchTimeoutRef.current = null;
+  }, []);
+
+  const clearAutoMetadataFetchTimeout = useCallback(() => {
+    if (metadataFetchTimeoutRef.current === null) return;
+    window.clearTimeout(metadataFetchTimeoutRef.current);
+    metadataFetchTimeoutRef.current = null;
+  }, []);
+
+  const invalidateAutoIconFetch = useCallback(() => {
+    clearAutoIconFetchTimeout();
+    autoFetchRequestRef.current += 1;
+    setIsFetchingIcon(false);
+  }, [clearAutoIconFetchTimeout]);
+
+  const invalidateAutoMetadataFetch = useCallback(() => {
+    clearAutoMetadataFetchTimeout();
+    metadataFetchRequestRef.current += 1;
+    setIsFetchingMetadata(false);
+  }, [clearAutoMetadataFetchTimeout]);
+
+  const applyFetchedMetadata = useCallback((
+    metadata: FetchedServiceMetadata,
+    mode: ServiceMetadataApplyMode
+  ): { name: boolean; description: boolean } => {
+    const updates = getServiceMetadataDraftUpdates(metadata, {
+      name: nameRef.current,
+      description: descriptionRef.current,
+      hasUserEditedName: hasUserEditedNameRef.current,
+      hasUserEditedDescription: hasUserEditedDescriptionRef.current,
+    }, mode);
+
+    if (updates.name !== undefined) {
+      nameRef.current = updates.name;
+      hasUserEditedNameRef.current = mode === SERVICE_METADATA_APPLY_MODES.REPLACE;
+      setName(updates.name);
+    }
+
+    if (updates.description !== undefined) {
+      descriptionRef.current = updates.description;
+      hasUserEditedDescriptionRef.current = mode === SERVICE_METADATA_APPLY_MODES.REPLACE;
+      setDescription(updates.description);
+    }
+
+    const appliedName = updates.name !== undefined;
+    const appliedDescription = updates.description !== undefined;
+
+    if (appliedName || appliedDescription) {
+      setErrors((current) => {
+        const next = { ...current };
+        if (appliedName) delete next.name;
+        if (appliedDescription) delete next.description;
+        return next;
+      });
+    }
+
+    return { name: appliedName, description: appliedDescription };
+  }, []);
 
   const cleanupFetchedIcon = useCallback((iconRef: FetchedIconRef) => {
     const formData = new FormData();
@@ -127,6 +224,86 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     return result.success ? result.data : null;
   };
 
+  const handleFetchServiceMetadata = useCallback(async ({
+    silent = false,
+    expectedUrl,
+    mode = SERVICE_METADATA_APPLY_MODES.REPLACE,
+  }: {
+    silent?: boolean;
+    expectedUrl?: string;
+    mode?: ServiceMetadataApplyMode;
+  } = {}): Promise<boolean> => {
+    if (!url || isSubmitting || isFetchingMetadata) return false;
+    const validUrl = getValidServiceUrl();
+    if (!validUrl) return false;
+    invalidateAutoMetadataFetch();
+
+    const requestId = metadataFetchRequestRef.current + 1;
+    metadataFetchRequestRef.current = requestId;
+    setIsFetchingMetadata(true);
+
+    if (!silent) {
+      setErrors((current) => {
+        const next = { ...current };
+        delete next.url;
+        return next;
+      });
+    }
+
+    const formData = new FormData();
+    formData.append('url', validUrl);
+
+    try {
+      const result = await fetchServiceMetadata(formData);
+      if (
+        metadataFetchRequestRef.current !== requestId ||
+        getLatestValidServiceUrl() !== validUrl ||
+        (silent && expectedUrl && validUrl !== expectedUrl)
+      ) {
+        return false;
+      }
+
+      if (result.success) {
+        const applied = applyFetchedMetadata(result.data, mode);
+
+        if (!silent) {
+          if (applied.name || applied.description) {
+            toast.success('Service details fetched');
+          } else {
+            toast.info('Service details found; existing fields were kept');
+          }
+        }
+        return applied.name || applied.description;
+      } else if (!silent) {
+        const errorMap: Record<string, string> = {};
+        result.errors.forEach((error) => {
+          errorMap[error.field] = error.message;
+        });
+        setErrors((current) => ({ ...current, ...errorMap }));
+        toast.error(result.errors[0]?.message ?? 'Failed to fetch service details');
+      }
+      return false;
+    } catch {
+      if (!silent) {
+        setErrors((current) => ({ ...current, url: 'Failed to fetch service details' }));
+        toast.error('Failed to fetch service details');
+      }
+      return false;
+    } finally {
+      if (metadataFetchRequestRef.current === requestId) {
+        setIsFetchingMetadata(false);
+      }
+    }
+  }, [
+    applyFetchedMetadata,
+    getLatestValidServiceUrl,
+    getValidServiceUrl,
+    isFetchingMetadata,
+    isSubmitting,
+    invalidateAutoMetadataFetch,
+    url,
+  ]);
+
   const handleFetchFavicon = useCallback(async ({
     silent = false,
     markManual = true,
@@ -135,11 +312,12 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     silent?: boolean;
     markManual?: boolean;
     expectedUrl?: string;
-  } = {}) => {
-    if (!url || isSubmitting || isFetchingIcon) return;
+  } = {}): Promise<boolean> => {
+    if (!url || isSubmitting || isFetchingIcon) return false;
     const validUrl = getValidServiceUrl();
-    if (!validUrl) return;
-    const iconFetchId = getIconFetchId(serviceId, validUrl);
+    if (!validUrl) return false;
+    invalidateAutoIconFetch();
+    const iconFetchId = getIconFetchId('', validUrl);
 
     if (markManual) {
       setIconControl('manual');
@@ -164,7 +342,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         if (result.success) {
           cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
         }
-        return;
+        return false;
       }
 
       if (result.success) {
@@ -175,6 +353,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         if (!silent) {
           toast.success('Favicon fetched');
         }
+        return true;
       } else if (!silent) {
         const errorMap: Record<string, string> = {};
         result.errors.forEach((error) => {
@@ -183,11 +362,13 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         setErrors((current) => ({ ...current, ...errorMap }));
         toast.error(result.errors[0]?.message ?? 'Failed to fetch favicon');
       }
+      return false;
     } catch {
       if (!silent) {
         setErrors((current) => ({ ...current, icon: 'Failed to fetch favicon' }));
         toast.error('Failed to fetch favicon');
       }
+      return false;
     } finally {
       setIsFetchingIcon(false);
     }
@@ -197,8 +378,45 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     getValidServiceUrl,
     isFetchingIcon,
     isSubmitting,
-    serviceId,
+    invalidateAutoIconFetch,
     trackProvisionalIcon,
+    url,
+  ]);
+
+  const handleFetchServiceDetails = useCallback(async () => {
+    if (!url || isSubmitting || isFetchingMetadata || isFetchingIcon) return;
+    const validUrl = getValidServiceUrl();
+    if (!validUrl) return;
+
+    setErrors((current) => {
+      const next = { ...current };
+      delete next.icon;
+      delete next.url;
+      return next;
+    });
+
+    const [metadataApplied, faviconApplied] = await Promise.all([
+      handleFetchServiceMetadata({ silent: true, mode: SERVICE_METADATA_APPLY_MODES.REPLACE }),
+      handleFetchFavicon({ silent: true, markManual: true }),
+    ]);
+
+    if (metadataApplied || faviconApplied) {
+      toast.success('Service details fetched');
+      return;
+    }
+
+    setErrors((current) => ({
+      ...current,
+      url: 'No service details found for this URL',
+    }));
+    toast.error('No service details found for this URL');
+  }, [
+    getValidServiceUrl,
+    handleFetchFavicon,
+    handleFetchServiceMetadata,
+    isFetchingIcon,
+    isFetchingMetadata,
+    isSubmitting,
     url,
   ]);
 
@@ -208,11 +426,15 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     const validUrl = getValidServiceUrl();
     if (!validUrl) return;
 
-    const iconFetchId = getIconFetchId(serviceId, validUrl);
+    const iconFetchId = getIconFetchId('', validUrl);
     const fetchKey = `${iconFetchId}:${validUrl}`;
     if (lastAutoFetchKeyRef.current === fetchKey) return;
 
     const timeout = window.setTimeout(() => {
+      if (autoFetchTimeoutRef.current === timeout) {
+        autoFetchTimeoutRef.current = null;
+      }
+
       const requestId = autoFetchRequestRef.current + 1;
       autoFetchRequestRef.current = requestId;
       setIsFetchingIcon(true);
@@ -221,52 +443,139 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       formData.append('serviceId', iconFetchId);
       formData.append('url', validUrl);
 
-      void fetchServiceIcon(formData).then((result) => {
-        if (
-          autoFetchRequestRef.current !== requestId ||
-          getLatestValidServiceUrl() !== validUrl
-        ) {
-          if (result.success) {
-            cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+      void (async () => {
+        try {
+          const result = await fetchServiceIcon(formData);
+          if (
+            autoFetchRequestRef.current !== requestId ||
+            getLatestValidServiceUrl() !== validUrl
+          ) {
+            if (result.success) {
+              cleanupFetchedIcon({ serviceId: iconFetchId, iconPath: result.data });
+            }
+            return;
           }
-          return;
-        }
 
-        lastAutoFetchKeyRef.current = fetchKey;
+          lastAutoFetchKeyRef.current = fetchKey;
 
-        if (result.success) {
-          trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
-          setPendingIconFile(null);
-          setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
-          setIconVersion((value) => value + 1);
+          if (result.success) {
+            trackProvisionalIcon({ serviceId: iconFetchId, iconPath: result.data });
+            setPendingIconFile(null);
+            setIcon({ type: ICON_TYPES.IMAGE, value: result.data });
+            setIconVersion((value) => value + 1);
+          }
+        } catch {
+          // Auto-fetch is best-effort; manual fetch reports errors to the user.
+        } finally {
+          if (autoFetchRequestRef.current === requestId) {
+            setIsFetchingIcon(false);
+          }
         }
-      }).finally(() => {
-        if (autoFetchRequestRef.current === requestId) {
-          setIsFetchingIcon(false);
-        }
-      });
+      })();
     }, 600);
+    autoFetchTimeoutRef.current = timeout;
 
-    return () => window.clearTimeout(timeout);
+    return () => {
+      window.clearTimeout(timeout);
+      if (autoFetchTimeoutRef.current === timeout) {
+        autoFetchTimeoutRef.current = null;
+      }
+    };
   }, [
     cleanupFetchedIcon,
     service,
     iconControl,
     pendingIconFile,
     isSubmitting,
-    serviceId,
     getLatestValidServiceUrl,
     getValidServiceUrl,
     trackProvisionalIcon,
+  ]);
+
+  useEffect(() => {
+    if (service || isSubmitting) return;
+
+    const validUrl = getValidServiceUrl();
+    if (!validUrl) return;
+    if (!hasFillableMetadataFields()) return;
+
+    const fetchKey = validUrl;
+    if (lastAutoMetadataFetchKeyRef.current === fetchKey) return;
+
+    const timeout = window.setTimeout(() => {
+      if (metadataFetchTimeoutRef.current === timeout) {
+        metadataFetchTimeoutRef.current = null;
+      }
+
+      const requestId = metadataFetchRequestRef.current + 1;
+      metadataFetchRequestRef.current = requestId;
+      setIsFetchingMetadata(true);
+
+      const formData = new FormData();
+      formData.append('url', validUrl);
+
+      void (async () => {
+        try {
+          const result = await fetchServiceMetadata(formData);
+          if (
+            metadataFetchRequestRef.current !== requestId ||
+            getLatestValidServiceUrl() !== validUrl
+          ) {
+            return;
+          }
+
+          lastAutoMetadataFetchKeyRef.current = fetchKey;
+
+          if (result.success) {
+            applyFetchedMetadata(result.data, SERVICE_METADATA_APPLY_MODES.FILL_EMPTY);
+          }
+        } catch {
+          // Auto-fetch is best-effort; manual fetch reports errors to the user.
+        } finally {
+          if (metadataFetchRequestRef.current === requestId) {
+            setIsFetchingMetadata(false);
+          }
+        }
+      })();
+    }, 600);
+    metadataFetchTimeoutRef.current = timeout;
+
+    return () => {
+      window.clearTimeout(timeout);
+      if (metadataFetchTimeoutRef.current === timeout) {
+        metadataFetchTimeoutRef.current = null;
+      }
+    };
+  }, [
+    applyFetchedMetadata,
+    hasFillableMetadataFields,
+    service,
+    isSubmitting,
+    getLatestValidServiceUrl,
+    getValidServiceUrl,
   ]);
 
   const handleUrlChange = (nextUrl: string) => {
     urlRef.current = nextUrl;
     setUrl(nextUrl);
 
+    if (!service) {
+      invalidateAutoMetadataFetch();
+      lastAutoMetadataFetchKeyRef.current = null;
+
+      if (!hasUserEditedNameRef.current) {
+        nameRef.current = '';
+        setName('');
+      }
+      if (!hasUserEditedDescriptionRef.current) {
+        descriptionRef.current = '';
+        setDescription('');
+      }
+    }
+
     if (service || iconControl !== 'auto') return;
 
-    autoFetchRequestRef.current += 1;
+    invalidateAutoIconFetch();
     lastAutoFetchKeyRef.current = null;
     if (icon?.type === ICON_TYPES.IMAGE) {
       releaseProvisionalIcon();
@@ -275,8 +584,20 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     }
   };
 
+  const handleNameChange = (nextName: string) => {
+    hasUserEditedNameRef.current = true;
+    nameRef.current = nextName;
+    setName(nextName);
+  };
+
+  const handleDescriptionChange = (nextDescription: string) => {
+    hasUserEditedDescriptionRef.current = true;
+    descriptionRef.current = nextDescription;
+    setDescription(nextDescription);
+  };
+
   const handleIconValueChange = (nextIcon: IconConfig | undefined) => {
-    autoFetchRequestRef.current += 1;
+    invalidateAutoIconFetch();
     releaseProvisionalIcon();
     setIconControl('manual');
     setIcon(nextIcon);
@@ -284,7 +605,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
 
   const handleIconFileSelect = (file: File | null) => {
     if (file) {
-      autoFetchRequestRef.current += 1;
+      invalidateAutoIconFetch();
       releaseProvisionalIcon();
       setIconControl('manual');
     }
@@ -292,7 +613,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
   };
 
   const handleIconClear = () => {
-    autoFetchRequestRef.current += 1;
+    invalidateAutoIconFetch();
     releaseProvisionalIcon();
     setIconControl('manual');
     setIcon(undefined);
@@ -300,6 +621,8 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    invalidateAutoIconFetch();
+    invalidateAutoMetadataFetch();
     setIsSubmitting(true);
     setErrors({});
 
@@ -339,6 +662,8 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     if (result.success) {
       releaseProvisionalIcon(result.data.icon?.type === ICON_TYPES.IMAGE ? result.data.icon.value : undefined);
       toast.success(service ? 'Service updated' : 'Service created');
+      nameRef.current = '';
+      descriptionRef.current = '';
       setName('');
       setDescription('');
       setUrl('');
@@ -346,6 +671,8 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       setIcon(undefined);
       setPendingIconFile(null);
       setIconControl('auto');
+      hasUserEditedNameRef.current = false;
+      hasUserEditedDescriptionRef.current = false;
       setActive(true);
       onSuccess?.();
     } else {
@@ -361,11 +688,36 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      <Field data-invalid={!!errors.url}>
+        <div className="flex items-center justify-between gap-3">
+          <FieldLabel>URL *</FieldLabel>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handleFetchServiceDetails()}
+            disabled={!getValidServiceUrl() || isSubmitting || isFetchingMetadata || isFetchingIcon}
+          >
+            <RefreshCw data-icon="inline-start" className={cn((isFetchingMetadata || isFetchingIcon) && 'animate-spin')} />
+            {isFetchingMetadata || isFetchingIcon ? 'Fetching...' : 'Fetch details'}
+          </Button>
+        </div>
+        <Input
+          value={url}
+          onChange={(e) => handleUrlChange(e.target.value)}
+          placeholder="https://example.com, http://192.168.1.1:8080"
+          type="url"
+          disabled={isSubmitting}
+          className="font-mono text-xs"
+        />
+        {errors.url && <FieldError>{errors.url}</FieldError>}
+      </Field>
+
       <Field data-invalid={!!errors.name}>
         <FieldLabel>Name *</FieldLabel>
         <Input
           value={name}
-          onChange={(e) => setName(e.target.value)}
+          onChange={(e) => handleNameChange(e.target.value)}
           placeholder="Enter service name"
           disabled={isSubmitting}
         />
@@ -379,26 +731,12 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         <FieldLabel>Description *</FieldLabel>
         <Textarea
           value={description}
-          onChange={(e) => setDescription(e.target.value)}
+          onChange={(e) => handleDescriptionChange(e.target.value)}
           placeholder="Enter service description"
           rows={3}
           disabled={isSubmitting}
         />
         {errors.description && <FieldError>{errors.description}</FieldError>}
-      </Field>
-
-      <Field data-invalid={!!errors.url}>
-        <FieldLabel>URL *</FieldLabel>
-        <Input
-          value={url}
-          onChange={(e) => handleUrlChange(e.target.value)}
-          placeholder="https://example.com, http://192.168.1.1:8080"
-          type="url"
-          disabled={isSubmitting}
-          className="font-mono text-xs"
-        />
-        <FieldDescription>Full URL including https:// or http://</FieldDescription>
-        {errors.url && <FieldError>{errors.url}</FieldError>}
       </Field>
 
       <Field data-invalid={!!errors.categoryId}>

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -396,9 +396,19 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     });
 
     const [metadataApplied, faviconApplied] = await Promise.all([
-      handleFetchServiceMetadata({ silent: true, mode: SERVICE_METADATA_APPLY_MODES.REPLACE }),
-      handleFetchFavicon({ silent: true, markManual: true }),
+      handleFetchServiceMetadata({
+        silent: true,
+        expectedUrl: validUrl,
+        mode: SERVICE_METADATA_APPLY_MODES.REPLACE,
+      }),
+      handleFetchFavicon({
+        silent: true,
+        expectedUrl: validUrl,
+        markManual: true,
+      }),
     ]);
+
+    if (getLatestValidServiceUrl() !== validUrl) return;
 
     if (metadataApplied || faviconApplied) {
       toast.success('Service details fetched');
@@ -411,6 +421,7 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
     }));
     toast.error('No service details found for this URL');
   }, [
+    getLatestValidServiceUrl,
     getValidServiceUrl,
     handleFetchFavicon,
     handleFetchServiceMetadata,

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -46,6 +46,12 @@ interface FetchedServiceMetadata {
   description?: string;
 }
 
+interface MetadataFetchResult {
+  found: boolean;
+  applied: boolean;
+  stale: boolean;
+}
+
 function parseServiceUrl(value: string): string | null {
   try {
     const parsed = new URL(value);
@@ -226,16 +232,22 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
 
   const handleFetchServiceMetadata = useCallback(async ({
     silent = false,
+    expectedDescription,
+    expectedName,
     expectedUrl,
     mode = SERVICE_METADATA_APPLY_MODES.REPLACE,
   }: {
     silent?: boolean;
+    expectedDescription?: string;
+    expectedName?: string;
     expectedUrl?: string;
     mode?: ServiceMetadataApplyMode;
-  } = {}): Promise<boolean> => {
-    if (!url || isSubmitting || isFetchingMetadata) return false;
+  } = {}): Promise<MetadataFetchResult> => {
+    const emptyResult: MetadataFetchResult = { found: false, applied: false, stale: false };
+
+    if (!url || isSubmitting || isFetchingMetadata) return emptyResult;
     const validUrl = getValidServiceUrl();
-    if (!validUrl) return false;
+    if (!validUrl) return emptyResult;
     invalidateAutoMetadataFetch();
 
     const requestId = metadataFetchRequestRef.current + 1;
@@ -260,20 +272,28 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         getLatestValidServiceUrl() !== validUrl ||
         (silent && expectedUrl && validUrl !== expectedUrl)
       ) {
-        return false;
+        return { found: false, applied: false, stale: true };
       }
 
       if (result.success) {
-        const applied = applyFetchedMetadata(result.data, mode);
+        const metadataToApply: FetchedServiceMetadata = {
+          title:
+            expectedName === undefined || nameRef.current === expectedName
+              ? result.data.title
+              : undefined,
+          description:
+            expectedDescription === undefined || descriptionRef.current === expectedDescription
+              ? result.data.description
+              : undefined,
+        };
+        const applied = applyFetchedMetadata(metadataToApply, mode);
 
         if (!silent) {
           if (applied.name || applied.description) {
             toast.success('Service details fetched');
-          } else {
-            toast.info('Service details found; existing fields were kept');
           }
         }
-        return applied.name || applied.description;
+        return { found: true, applied: applied.name || applied.description, stale: false };
       } else if (!silent) {
         const errorMap: Record<string, string> = {};
         result.errors.forEach((error) => {
@@ -282,13 +302,13 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
         setErrors((current) => ({ ...current, ...errorMap }));
         toast.error(result.errors[0]?.message ?? 'Failed to fetch service details');
       }
-      return false;
+      return emptyResult;
     } catch {
       if (!silent) {
         setErrors((current) => ({ ...current, url: 'Failed to fetch service details' }));
         toast.error('Failed to fetch service details');
       }
-      return false;
+      return emptyResult;
     } finally {
       if (metadataFetchRequestRef.current === requestId) {
         setIsFetchingMetadata(false);
@@ -395,9 +415,11 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       return next;
     });
 
-    const [metadataApplied, faviconApplied] = await Promise.all([
+    const [metadataResult, faviconApplied] = await Promise.all([
       handleFetchServiceMetadata({
         silent: true,
+        expectedDescription: descriptionRef.current,
+        expectedName: nameRef.current,
         expectedUrl: validUrl,
         mode: SERVICE_METADATA_APPLY_MODES.REPLACE,
       }),
@@ -408,12 +430,15 @@ export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey
       }),
     ]);
 
-    if (getLatestValidServiceUrl() !== validUrl) return;
+    if (metadataResult.stale || getLatestValidServiceUrl() !== validUrl) return;
 
-    if (metadataApplied || faviconApplied) {
+    if (metadataResult.applied || faviconApplied) {
       toast.success('Service details fetched');
       return;
     }
+
+    // Metadata existed, but user edits prevented applying any fields.
+    if (metadataResult.found) return;
 
     setErrors((current) => ({
       ...current,

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from 'next/cache';
 import { collectConfigImportWarnings } from './config-import';
 import { readConfig, readRawConfig, writeConfig, writeRawConfigIfRevisionMatches } from './db';
 import { fetchProvisionalServiceFavicon, fetchServiceFavicon } from './favicon';
+import { fetchServiceMetadata as fetchServiceMetadataForUrl, type ServiceMetadata } from './service-metadata';
 import {
   appSettingsSchema,
   categorySchema,
@@ -231,6 +232,33 @@ export async function fetchServiceIcon(formData: FormData): Promise<ActionResult
   } catch (error) {
     console.error('Fetch service icon error:', error);
     return { success: false, errors: [{ field: 'icon', message: 'Failed to fetch favicon' }] };
+  }
+}
+
+export async function fetchServiceMetadata(formData: FormData): Promise<ActionResult<ServiceMetadata>> {
+  try {
+    const serviceUrl = formData.get('url') as string;
+
+    const urlValidation = serviceSchema.shape.url.safeParse(serviceUrl);
+    if (!urlValidation.success) {
+      return {
+        success: false,
+        errors: [{ field: 'url', message: urlValidation.error.issues[0]?.message ?? 'Must be a valid URL' }],
+      };
+    }
+
+    const metadata = await fetchServiceMetadataForUrl(urlValidation.data);
+    if (!metadata) {
+      return {
+        success: false,
+        errors: [{ field: 'url', message: 'No title or description metadata found for this URL' }],
+      };
+    }
+
+    return { success: true, data: metadata };
+  } catch (error) {
+    console.error('Fetch service metadata error:', error);
+    return { success: false, errors: [{ field: 'url', message: 'Failed to fetch service details' }] };
   }
 }
 

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { parse, type DefaultTreeAdapterTypes } from 'parse5';
 import {
   MAX_FILE_SIZE,
   getImageExtensionForContentType,
@@ -13,7 +14,6 @@ import {
   getTimeoutSignal,
   isHttpUrl,
   normalizeContentType,
-  parseAttributes,
   readResponseBuffer,
 } from './service-url-fetch';
 
@@ -25,14 +25,40 @@ interface IconCandidate {
   source: 'html' | 'fallback';
 }
 
+function isElement(node: DefaultTreeAdapterTypes.Node): node is DefaultTreeAdapterTypes.Element {
+  return 'tagName' in node;
+}
+
+function getAttribute(node: DefaultTreeAdapterTypes.Element, name: string): string | undefined {
+  const attr = node.attrs.find((item) => item.name.toLowerCase() === name);
+  return attr?.value;
+}
+
+function findElements(
+  node: DefaultTreeAdapterTypes.Node,
+  tagName: string,
+  results: DefaultTreeAdapterTypes.Element[] = []
+): DefaultTreeAdapterTypes.Element[] {
+  if (isElement(node) && node.tagName === tagName) {
+    results.push(node);
+  }
+
+  if ('childNodes' in node) {
+    for (const child of node.childNodes) {
+      findElements(child, tagName, results);
+    }
+  }
+
+  return results;
+}
+
 function parseIconCandidates(html: string, baseUrl: URL): IconCandidate[] {
   const candidates: IconCandidate[] = [];
-  const linkPattern = /<link\b[^>]*>/gi;
+  const document = parse(html);
 
-  for (const match of html.matchAll(linkPattern)) {
-    const attrs = parseAttributes(match[0]);
-    const rel = attrs.rel?.toLowerCase() ?? '';
-    const href = attrs.href;
+  for (const link of findElements(document, 'link')) {
+    const rel = getAttribute(link, 'rel')?.toLowerCase() ?? '';
+    const href = getAttribute(link, 'href');
 
     if (!href || !rel.split(/\s+/).some((part) => part === 'icon' || part.startsWith('apple-touch-icon'))) {
       continue;
@@ -45,8 +71,8 @@ function parseIconCandidates(html: string, baseUrl: URL): IconCandidate[] {
       candidates.push({
         url,
         rel,
-        type: attrs.type,
-        sizes: attrs.sizes,
+        type: getAttribute(link, 'type'),
+        sizes: getAttribute(link, 'sizes'),
         source: 'html',
       });
     } catch {

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -6,11 +6,16 @@ import {
   isAllowedImageMime,
 } from './image-constants';
 import { getProvisionalIconFilename, writeIconBuffer } from './file-utils';
-
-const FAVICON_FETCH_TIMEOUT_MS = 4_000;
-const FAVICON_PAGE_MAX_BYTES = 512 * 1024;
-const FAVICON_MAX_REDIRECTS = 3;
-const FAVICON_USER_AGENT = 'crapdash-favicon-fetcher/1.0';
+import {
+  SERVICE_FETCH_USER_AGENT,
+  fetchPageHtml,
+  fetchWithRedirects,
+  getTimeoutSignal,
+  isHttpUrl,
+  normalizeContentType,
+  parseAttributes,
+  readResponseBuffer,
+} from './service-url-fetch';
 
 interface IconCandidate {
   url: URL;
@@ -18,31 +23,6 @@ interface IconCandidate {
   type?: string;
   sizes?: string;
   source: 'html' | 'fallback';
-}
-
-function isHttpUrl(url: URL): boolean {
-  return url.protocol === 'http:' || url.protocol === 'https:';
-}
-
-function getTimeoutSignal(): AbortSignal {
-  return AbortSignal.timeout(FAVICON_FETCH_TIMEOUT_MS);
-}
-
-function normalizeContentType(value: string | null): string {
-  return value?.toLowerCase().split(';')[0]?.trim() ?? '';
-}
-
-function parseAttributes(tag: string): Record<string, string> {
-  const attrs: Record<string, string> = {};
-  const attrPattern = /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-
-  for (const match of tag.matchAll(attrPattern)) {
-    const [, rawName, doubleQuoted, singleQuoted, unquoted] = match;
-    if (!rawName || rawName.toLowerCase() === 'link') continue;
-    attrs[rawName.toLowerCase()] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
-  }
-
-  return attrs;
 }
 
 function parseIconCandidates(html: string, baseUrl: URL): IconCandidate[] {
@@ -123,60 +103,6 @@ function dedupeAndSortCandidates(candidates: IconCandidate[]): IconCandidate[] {
   return [...byUrl.values()].sort((a, b) => scoreCandidate(b) - scoreCandidate(a));
 }
 
-async function fetchWithRedirects(
-  url: URL,
-  init: RequestInit,
-  redirects = 0
-): Promise<{ response: Response; url: URL }> {
-  const response = await fetch(url, {
-    ...init,
-    redirect: 'manual',
-  });
-
-  if (![301, 302, 303, 307, 308].includes(response.status)) {
-    return { response, url };
-  }
-
-  if (redirects >= FAVICON_MAX_REDIRECTS) {
-    return { response, url };
-  }
-
-  const location = response.headers.get('location');
-  if (!location) return { response, url };
-
-  const nextUrl = new URL(location, url);
-  if (!isHttpUrl(nextUrl)) return { response, url };
-
-  return fetchWithRedirects(nextUrl, init, redirects + 1);
-}
-
-async function readResponseBuffer(response: Response, maxBytes: number): Promise<Buffer | null> {
-  if (!response.body) {
-    const arrayBuffer = await response.arrayBuffer();
-    return arrayBuffer.byteLength <= maxBytes ? Buffer.from(arrayBuffer) : null;
-  }
-
-  const reader = response.body.getReader();
-  const chunks: Uint8Array[] = [];
-  let total = 0;
-
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    if (!value) continue;
-
-    total += value.byteLength;
-    if (total > maxBytes) {
-      await reader.cancel();
-      return null;
-    }
-
-    chunks.push(value);
-  }
-
-  return Buffer.concat(chunks);
-}
-
 function sniffImageExtension(buffer: Buffer): string | null {
   if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
     return '.png';
@@ -224,34 +150,11 @@ function getExtensionFromUrl(url: URL): string | null {
   return ext && isAllowedImageExtension(ext) ? ext : null;
 }
 
-async function fetchPageHtml(serviceUrl: URL): Promise<{ html: string; pageUrl: URL } | null> {
-  const { response, url } = await fetchWithRedirects(serviceUrl, {
-    headers: {
-      Accept: 'text/html,application/xhtml+xml',
-      'User-Agent': FAVICON_USER_AGENT,
-    },
-    signal: getTimeoutSignal(),
-  });
-
-  if (!response.ok) return null;
-
-  const contentType = normalizeContentType(response.headers.get('content-type'));
-  if (contentType && !contentType.includes('html')) return null;
-
-  const buffer = await readResponseBuffer(response, FAVICON_PAGE_MAX_BYTES);
-  if (!buffer) return null;
-
-  return {
-    html: buffer.toString('utf8'),
-    pageUrl: url,
-  };
-}
-
 async function fetchIconCandidate(candidate: IconCandidate): Promise<{ buffer: Buffer; ext: string } | null> {
   const { response } = await fetchWithRedirects(candidate.url, {
     headers: {
       Accept: 'image/avif,image/webp,image/svg+xml,image/png,image/*,*/*;q=0.8',
-      'User-Agent': FAVICON_USER_AGENT,
+      'User-Agent': SERVICE_FETCH_USER_AGENT,
     },
     signal: getTimeoutSignal(),
   });

--- a/lib/service-metadata-apply.ts
+++ b/lib/service-metadata-apply.ts
@@ -1,0 +1,69 @@
+import type { ServiceMetadata } from './service-metadata';
+
+export const SERVICE_METADATA_APPLY_MODES = {
+  FILL_EMPTY: 'fill-empty',
+  REPLACE: 'replace',
+} as const;
+
+export type ServiceMetadataApplyMode =
+  typeof SERVICE_METADATA_APPLY_MODES[keyof typeof SERVICE_METADATA_APPLY_MODES];
+
+export interface ServiceMetadataDraftState {
+  name: string;
+  description: string;
+  hasUserEditedName: boolean;
+  hasUserEditedDescription: boolean;
+}
+
+export interface ServiceMetadataDraftUpdates {
+  name?: string;
+  description?: string;
+}
+
+function shouldApplyField({
+  mode,
+  currentValue,
+  hasUserEdited,
+}: {
+  mode: ServiceMetadataApplyMode;
+  currentValue: string;
+  hasUserEdited: boolean;
+}): boolean {
+  return (
+    mode === SERVICE_METADATA_APPLY_MODES.REPLACE ||
+    !hasUserEdited ||
+    currentValue.trim().length === 0
+  );
+}
+
+export function getServiceMetadataDraftUpdates(
+  metadata: ServiceMetadata,
+  draft: ServiceMetadataDraftState,
+  mode: ServiceMetadataApplyMode
+): ServiceMetadataDraftUpdates {
+  const updates: ServiceMetadataDraftUpdates = {};
+
+  if (
+    metadata.title &&
+    shouldApplyField({
+      mode,
+      currentValue: draft.name,
+      hasUserEdited: draft.hasUserEditedName,
+    })
+  ) {
+    updates.name = metadata.title;
+  }
+
+  if (
+    metadata.description &&
+    shouldApplyField({
+      mode,
+      currentValue: draft.description,
+      hasUserEdited: draft.hasUserEditedDescription,
+    })
+  ) {
+    updates.description = metadata.description;
+  }
+
+  return updates;
+}

--- a/lib/service-metadata.ts
+++ b/lib/service-metadata.ts
@@ -1,48 +1,14 @@
+import { parse, type DefaultTreeAdapterTypes } from 'parse5';
 import { SERVICE_DESCRIPTION_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH } from './validations';
-import { fetchPageHtml, isHttpUrl, parseAttributes } from './service-url-fetch';
+import { fetchPageHtml, isHttpUrl } from './service-url-fetch';
 
 export interface ServiceMetadata {
   title?: string;
   description?: string;
 }
 
-const HTML_ENTITIES: Record<string, string> = {
-  amp: '&',
-  apos: "'",
-  gt: '>',
-  lt: '<',
-  nbsp: ' ',
-  quot: '"',
-};
-
-function decodeHtmlEntities(value: string): string {
-  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi, (entity, rawName: string) => {
-    const name = rawName.toLowerCase();
-
-    if (name.startsWith('#x')) {
-      const codePoint = Number.parseInt(name.slice(2), 16);
-      try {
-        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
-      } catch {
-        return entity;
-      }
-    }
-
-    if (name.startsWith('#')) {
-      const codePoint = Number.parseInt(name.slice(1), 10);
-      try {
-        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
-      } catch {
-        return entity;
-      }
-    }
-
-    return HTML_ENTITIES[name] ?? entity;
-  });
-}
-
 function normalizeMetadataText(value: string, maxLength: number): string | undefined {
-  const normalized = decodeHtmlEntities(value)
+  const normalized = value
     .replace(/\s+/g, ' ')
     .trim();
 
@@ -50,30 +16,72 @@ function normalizeMetadataText(value: string, maxLength: number): string | undef
   return normalized.length > maxLength ? normalized.slice(0, maxLength).trim() : normalized;
 }
 
-function extractTitle(html: string): string | undefined {
-  const match = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html);
-  return match?.[1] ? normalizeMetadataText(match[1], SERVICE_NAME_MAX_LENGTH) : undefined;
+function isElement(node: DefaultTreeAdapterTypes.Node): node is DefaultTreeAdapterTypes.Element {
+  return 'tagName' in node;
 }
 
-function extractDescription(html: string): string | undefined {
-  const metaPattern = /<meta\b[^>]*>/gi;
+function isTextNode(node: DefaultTreeAdapterTypes.Node): node is DefaultTreeAdapterTypes.TextNode {
+  return node.nodeName === '#text' && 'value' in node;
+}
 
-  for (const match of html.matchAll(metaPattern)) {
-    const attrs = parseAttributes(match[0]);
-    if (attrs.name?.toLowerCase() !== 'description') continue;
-    if (!attrs.content) continue;
+function getAttribute(node: DefaultTreeAdapterTypes.Element, name: string): string | undefined {
+  const attr = node.attrs.find((item) => item.name.toLowerCase() === name);
+  return attr?.value;
+}
 
-    const description = normalizeMetadataText(attrs.content, SERVICE_DESCRIPTION_MAX_LENGTH);
-    if (description) return description;
+function getTextContent(node: DefaultTreeAdapterTypes.Node): string {
+  if (isTextNode(node)) {
+    return node.value;
+  }
+
+  if ('childNodes' in node) {
+    return node.childNodes.map(getTextContent).join('');
+  }
+
+  return '';
+}
+
+function findElement(
+  node: DefaultTreeAdapterTypes.Node,
+  predicate: (element: DefaultTreeAdapterTypes.Element) => boolean
+): DefaultTreeAdapterTypes.Element | undefined {
+  if (isElement(node) && predicate(node)) {
+    return node;
+  }
+
+  if (!('childNodes' in node)) {
+    return undefined;
+  }
+
+  for (const child of node.childNodes) {
+    const match = findElement(child, predicate);
+    if (match) return match;
   }
 
   return undefined;
 }
 
+function extractTitle(document: DefaultTreeAdapterTypes.Document): string | undefined {
+  const title = findElement(document, (element) => element.tagName === 'title');
+  return title ? normalizeMetadataText(getTextContent(title), SERVICE_NAME_MAX_LENGTH) : undefined;
+}
+
+function extractDescription(document: DefaultTreeAdapterTypes.Document): string | undefined {
+  const meta = findElement(document, (element) => {
+    if (element.tagName !== 'meta') return false;
+    return getAttribute(element, 'name')?.toLowerCase() === 'description';
+  });
+
+  const content = meta ? getAttribute(meta, 'content') : undefined;
+  return content ? normalizeMetadataText(content, SERVICE_DESCRIPTION_MAX_LENGTH) : undefined;
+}
+
 export function parseServiceMetadata(html: string): ServiceMetadata {
+  const document = parse(html);
+
   return {
-    title: extractTitle(html),
-    description: extractDescription(html),
+    title: extractTitle(document),
+    description: extractDescription(document),
   };
 }
 

--- a/lib/service-metadata.ts
+++ b/lib/service-metadata.ts
@@ -1,0 +1,96 @@
+import { SERVICE_DESCRIPTION_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH } from './validations';
+import { fetchPageHtml, isHttpUrl, parseAttributes } from './service-url-fetch';
+
+export interface ServiceMetadata {
+  title?: string;
+  description?: string;
+}
+
+const HTML_ENTITIES: Record<string, string> = {
+  amp: '&',
+  apos: "'",
+  gt: '>',
+  lt: '<',
+  nbsp: ' ',
+  quot: '"',
+};
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z][a-z0-9]+);/gi, (entity, rawName: string) => {
+    const name = rawName.toLowerCase();
+
+    if (name.startsWith('#x')) {
+      const codePoint = Number.parseInt(name.slice(2), 16);
+      try {
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
+      } catch {
+        return entity;
+      }
+    }
+
+    if (name.startsWith('#')) {
+      const codePoint = Number.parseInt(name.slice(1), 10);
+      try {
+        return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : entity;
+      } catch {
+        return entity;
+      }
+    }
+
+    return HTML_ENTITIES[name] ?? entity;
+  });
+}
+
+function normalizeMetadataText(value: string, maxLength: number): string | undefined {
+  const normalized = decodeHtmlEntities(value)
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!normalized) return undefined;
+  return normalized.length > maxLength ? normalized.slice(0, maxLength).trim() : normalized;
+}
+
+function extractTitle(html: string): string | undefined {
+  const match = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  return match?.[1] ? normalizeMetadataText(match[1], SERVICE_NAME_MAX_LENGTH) : undefined;
+}
+
+function extractDescription(html: string): string | undefined {
+  const metaPattern = /<meta\b[^>]*>/gi;
+
+  for (const match of html.matchAll(metaPattern)) {
+    const attrs = parseAttributes(match[0]);
+    if (attrs.name?.toLowerCase() !== 'description') continue;
+    if (!attrs.content) continue;
+
+    const description = normalizeMetadataText(attrs.content, SERVICE_DESCRIPTION_MAX_LENGTH);
+    if (description) return description;
+  }
+
+  return undefined;
+}
+
+export function parseServiceMetadata(html: string): ServiceMetadata {
+  return {
+    title: extractTitle(html),
+    description: extractDescription(html),
+  };
+}
+
+export async function fetchServiceMetadata(serviceUrl: string): Promise<ServiceMetadata | null> {
+  try {
+    const url = new URL(serviceUrl);
+    if (!isHttpUrl(url)) return null;
+
+    const page = await fetchPageHtml(url);
+    if (!page) return null;
+
+    const metadata = parseServiceMetadata(page.html);
+    return metadata.title || metadata.description ? metadata : null;
+  } catch (error) {
+    if (error instanceof Error && error.name !== 'TimeoutError' && error.name !== 'AbortError') {
+      console.error('Service metadata fetch error:', error);
+    }
+    return null;
+  }
+}

--- a/lib/service-url-fetch.ts
+++ b/lib/service-url-fetch.ts
@@ -15,23 +15,6 @@ export function normalizeContentType(value: string | null): string {
   return value?.toLowerCase().split(';')[0]?.trim() ?? '';
 }
 
-export function parseAttributes(tag: string): Record<string, string> {
-  const attrs: Record<string, string> = {};
-  const attrPattern = /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
-
-  for (const match of tag.matchAll(attrPattern)) {
-    const [, rawName, doubleQuoted, singleQuoted, unquoted] = match;
-    if (!rawName) continue;
-
-    const name = rawName.toLowerCase();
-    if (name === 'link' || name === 'meta' || name === 'title') continue;
-
-    attrs[name] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
-  }
-
-  return attrs;
-}
-
 export async function fetchWithRedirects(
   url: URL,
   init: RequestInit,

--- a/lib/service-url-fetch.ts
+++ b/lib/service-url-fetch.ts
@@ -1,0 +1,110 @@
+const SERVICE_FETCH_TIMEOUT_MS = 4_000;
+const SERVICE_PAGE_MAX_BYTES = 512 * 1024;
+const SERVICE_MAX_REDIRECTS = 3;
+export const SERVICE_FETCH_USER_AGENT = 'crapdash-service-fetcher/1.0';
+
+export function isHttpUrl(url: URL): boolean {
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+export function getTimeoutSignal(): AbortSignal {
+  return AbortSignal.timeout(SERVICE_FETCH_TIMEOUT_MS);
+}
+
+export function normalizeContentType(value: string | null): string {
+  return value?.toLowerCase().split(';')[0]?.trim() ?? '';
+}
+
+export function parseAttributes(tag: string): Record<string, string> {
+  const attrs: Record<string, string> = {};
+  const attrPattern = /([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g;
+
+  for (const match of tag.matchAll(attrPattern)) {
+    const [, rawName, doubleQuoted, singleQuoted, unquoted] = match;
+    if (!rawName) continue;
+
+    const name = rawName.toLowerCase();
+    if (name === 'link' || name === 'meta' || name === 'title') continue;
+
+    attrs[name] = doubleQuoted ?? singleQuoted ?? unquoted ?? '';
+  }
+
+  return attrs;
+}
+
+export async function fetchWithRedirects(
+  url: URL,
+  init: RequestInit,
+  redirects = 0
+): Promise<{ response: Response; url: URL }> {
+  const response = await fetch(url, {
+    ...init,
+    redirect: 'manual',
+  });
+
+  if (![301, 302, 303, 307, 308].includes(response.status)) {
+    return { response, url };
+  }
+
+  if (redirects >= SERVICE_MAX_REDIRECTS) {
+    return { response, url };
+  }
+
+  const location = response.headers.get('location');
+  if (!location) return { response, url };
+
+  const nextUrl = new URL(location, url);
+  if (!isHttpUrl(nextUrl)) return { response, url };
+
+  return fetchWithRedirects(nextUrl, init, redirects + 1);
+}
+
+export async function readResponseBuffer(response: Response, maxBytes: number): Promise<Buffer | null> {
+  if (!response.body) {
+    const arrayBuffer = await response.arrayBuffer();
+    return arrayBuffer.byteLength <= maxBytes ? Buffer.from(arrayBuffer) : null;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    total += value.byteLength;
+    if (total > maxBytes) {
+      await reader.cancel();
+      return null;
+    }
+
+    chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+export async function fetchPageHtml(serviceUrl: URL): Promise<{ html: string; pageUrl: URL } | null> {
+  const { response, url } = await fetchWithRedirects(serviceUrl, {
+    headers: {
+      Accept: 'text/html,application/xhtml+xml',
+      'User-Agent': SERVICE_FETCH_USER_AGENT,
+    },
+    signal: getTimeoutSignal(),
+  });
+
+  if (!response.ok) return null;
+
+  const contentType = normalizeContentType(response.headers.get('content-type'));
+  if (contentType && !contentType.includes('html')) return null;
+
+  const buffer = await readResponseBuffer(response, SERVICE_PAGE_MAX_BYTES);
+  if (!buffer) return null;
+
+  return {
+    html: buffer.toString('utf8'),
+    pageUrl: url,
+  };
+}

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 import { ICON_TYPES } from './types';
 import { resolveLucideIconName } from './lucide-icons';
 
+export const SERVICE_NAME_MAX_LENGTH = 100;
+export const SERVICE_DESCRIPTION_MAX_LENGTH = 500;
+
 export const slugSchema = z.string().regex(
   /^[a-z0-9-]+$/i,
   'Slug must use letters, numbers, or dashes'
@@ -63,8 +66,8 @@ export const categoryCreateSchema = categorySchema.extend({
 });
 
 export const serviceSchema = z.object({
-  name: z.string().min(1, 'Name is required').max(100, 'Name must be less than 100 characters'),
-  description: z.string().min(1, 'Description is required').max(500, 'Description must be less than 500 characters'),
+  name: z.string().min(1, 'Name is required').max(SERVICE_NAME_MAX_LENGTH, 'Name must be less than 100 characters'),
+  description: z.string().min(1, 'Description is required').max(SERVICE_DESCRIPTION_MAX_LENGTH, 'Description must be less than 500 characters'),
   url: z.string().url('Must be a valid URL'),
   categoryId: z.string().min(1, 'Category is required'),
   icon: iconConfigSchema.optional(),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crapdash",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@11.0.3",
@@ -39,6 +39,7 @@
     "motion": "^12.42.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
+    "parse5": "^8.0.1",
     "radix-ui": "^1.6.0",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      parse5:
+        specifier: ^8.0.1
+        version: 8.0.1
       radix-ui:
         specifier: ^1.6.0
         version: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -2433,6 +2436,10 @@ packages:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -3526,6 +3533,9 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -6565,6 +6575,8 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@8.0.0: {}
+
   env-paths@2.2.1: {}
 
   error-ex@1.3.4:
@@ -7776,6 +7788,10 @@ snapshots:
       lines-and-columns: 1.2.4
 
   parse-ms@4.0.0: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   parseurl@1.3.3: {}
 

--- a/tests/lib/favicon.test.ts
+++ b/tests/lib/favicon.test.ts
@@ -121,4 +121,28 @@ describe('favicon fetching', () => {
     await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.png');
     await expect(readFile(path.join(getIconsDir(), 'example.png'))).resolves.toEqual(png);
   });
+
+  it('decodes entity references in icon attributes', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg" />';
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('<link rel="icon" href="/icons/a&amp;b.svg" type="image/svg+xml">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      if (url === 'https://example.com/icons/a&b.svg') {
+        return response(svg, {
+          headers: { 'content-type': 'image/svg+xml' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceFavicon('https://example.com/', 'example')).resolves.toBe('icons/example.svg');
+    await expect(readFile(path.join(getIconsDir(), 'example.svg'), 'utf-8')).resolves.toBe(svg);
+  });
 });

--- a/tests/lib/service-metadata-apply.test.ts
+++ b/tests/lib/service-metadata-apply.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SERVICE_METADATA_APPLY_MODES,
+  getServiceMetadataDraftUpdates,
+} from '@/lib/service-metadata-apply';
+
+describe('service metadata draft updates', () => {
+  it('fills empty or unowned fields during automatic metadata fetches', () => {
+    expect(getServiceMetadataDraftUpdates(
+      { title: 'Fetched Title', description: 'Fetched description' },
+      {
+        name: 'Typed name',
+        description: '',
+        hasUserEditedName: true,
+        hasUserEditedDescription: true,
+      },
+      SERVICE_METADATA_APPLY_MODES.FILL_EMPTY
+    )).toEqual({ description: 'Fetched description' });
+
+    expect(getServiceMetadataDraftUpdates(
+      { title: 'Fetched Title', description: 'Fetched description' },
+      {
+        name: 'Auto name',
+        description: 'Auto description',
+        hasUserEditedName: false,
+        hasUserEditedDescription: false,
+      },
+      SERVICE_METADATA_APPLY_MODES.FILL_EMPTY
+    )).toEqual({
+      name: 'Fetched Title',
+      description: 'Fetched description',
+    });
+  });
+
+  it('overwrites draft fields during manual metadata fetches', () => {
+    expect(getServiceMetadataDraftUpdates(
+      { title: 'Fetched Title', description: 'Fetched description' },
+      {
+        name: 'Typed name',
+        description: 'Typed description',
+        hasUserEditedName: true,
+        hasUserEditedDescription: true,
+      },
+      SERVICE_METADATA_APPLY_MODES.REPLACE
+    )).toEqual({
+      name: 'Fetched Title',
+      description: 'Fetched description',
+    });
+  });
+
+  it('only updates fields that were actually fetched', () => {
+    expect(getServiceMetadataDraftUpdates(
+      { title: 'Fetched Title' },
+      {
+        name: 'Typed name',
+        description: 'Typed description',
+        hasUserEditedName: true,
+        hasUserEditedDescription: true,
+      },
+      SERVICE_METADATA_APPLY_MODES.REPLACE
+    )).toEqual({ name: 'Fetched Title' });
+  });
+});

--- a/tests/lib/service-metadata.test.ts
+++ b/tests/lib/service-metadata.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchServiceMetadata, parseServiceMetadata } from '@/lib/service-metadata';
+
+function response(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, init);
+}
+
+describe('service metadata', () => {
+  it('extracts title from the document title and description from meta name description', () => {
+    const html = `
+      <html>
+        <head>
+          <title> Example &amp; Service </title>
+          <meta name="description" content=" Runs the important things. ">
+        </head>
+      </html>
+    `;
+
+    expect(parseServiceMetadata(html)).toEqual({
+      title: 'Example & Service',
+      description: 'Runs the important things.',
+    });
+  });
+
+  it('does not use Open Graph or Twitter descriptions as fallbacks', () => {
+    const html = `
+      <html>
+        <head>
+          <title>Example</title>
+          <meta property="og:description" content="Do not use this">
+          <meta name="twitter:description" content="Do not use this either">
+        </head>
+      </html>
+    `;
+
+    expect(parseServiceMetadata(html)).toEqual({
+      title: 'Example',
+      description: undefined,
+    });
+  });
+
+  it('normalizes whitespace, decodes entities, and applies service limits', () => {
+    const longDescription = `${'A'.repeat(510)} &amp; more`;
+    const html = `
+      <html>
+        <head>
+          <title>
+            Line&#x20;One
+            Line&nbsp;Two
+          </title>
+          <meta name="description" content="${longDescription}">
+        </head>
+      </html>
+    `;
+
+    const metadata = parseServiceMetadata(html);
+
+    expect(metadata.title).toBe('Line One Line Two');
+    expect(metadata.description).toHaveLength(500);
+    expect(metadata.description).toBe('A'.repeat(500));
+  });
+
+  it('preserves encoded angle-bracket text in titles and descriptions', () => {
+    const html = `
+      <html>
+        <head>
+          <title>ACME &lt;Preview&gt;</title>
+          <meta name="description" content="Tools for ACME &lt;Preview&gt;">
+        </head>
+      </html>
+    `;
+
+    expect(parseServiceMetadata(html)).toEqual({
+      title: 'ACME <Preview>',
+      description: 'Tools for ACME <Preview>',
+    });
+  });
+
+  it('resolves metadata from the final page after redirects', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url === 'https://example.com/') {
+        return response('', {
+          status: 302,
+          headers: { location: 'https://example.com/app/' },
+        });
+      }
+
+      if (url === 'https://example.com/app/') {
+        return response('<title>Redirected App</title><meta name="description" content="Final page description">', {
+          headers: { 'content-type': 'text/html' },
+        });
+      }
+
+      return response('', { status: 404 });
+    });
+
+    await expect(fetchServiceMetadata('https://example.com/')).resolves.toEqual({
+      title: 'Redirected App',
+      description: 'Final page description',
+    });
+  });
+
+  it('returns null when the response is not HTML or has no supported metadata', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(response('{"name":"Example"}', {
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    await expect(fetchServiceMetadata('https://example.com/')).resolves.toBeNull();
+  });
+});

--- a/tests/lib/service-metadata.test.ts
+++ b/tests/lib/service-metadata.test.ts
@@ -76,6 +76,31 @@ describe('service metadata', () => {
     });
   });
 
+  it('decodes standard named entities with the HTML parser', () => {
+    const html = `
+      <TITLE>Tom &amp; Jerry&rsquo;s Monitor &mdash; Live</TITLE>
+      <META NAME="description" CONTENT="Status &hellip; 5 &lt; 6">
+    `;
+
+    expect(parseServiceMetadata(html)).toEqual({
+      title: 'Tom & Jerry\u2019s Monitor \u2014 Live',
+      description: 'Status \u2026 5 < 6',
+    });
+  });
+
+  it('recovers metadata from loose real-world HTML', () => {
+    const html = `
+      <meta content="Description before title &copy;" name="description">
+      <title>
+        Loose&nbsp;title
+    `;
+
+    expect(parseServiceMetadata(html)).toEqual({
+      title: 'Loose title',
+      description: 'Description before title \u00a9',
+    });
+  });
+
   it('resolves metadata from the final page after redirects', async () => {
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (input) => {
       const url = String(input);


### PR DESCRIPTION
## Summary

Adds service metadata fetching to the "Add Service" form so a configured URL can automatically populate "Name" and "Description", alongside existing automatic favicon fetching.
