### PR TITLE
Fix footer GitHub link hit area

### DIFF
--- a/components/layout/footer/page-footer.tsx
+++ b/components/layout/footer/page-footer.tsx
@@ -7,25 +7,29 @@ export function PageFooter() {
 
   return (
     <footer className="fixed bottom-3 right-4 sm:right-6">
-      <div className="flex items-center gap-1 text-xs text-muted-foreground/60 font-mono bg-background/80 backdrop-blur-sm pl-1 pr-2 py-1 rounded">
-        <Button variant="ghost" size="icon-xs" asChild>
-          <a
-            href="https://github.com/austin-smith/crapdash"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="View on GitHub"
-          >
-            <Image
-              src="/github-mark.svg"
-              alt="GitHub"
-              width={12}
-              height={12}
-              className="opacity-60 group-hover/button:opacity-100 transition-opacity dark:invert"
-            />
-          </a>
-        </Button>
-        <span>{DEFAULT_APP_TITLE} {version}</span>
-      </div>
+      <Button
+        variant="ghost"
+        size="xs"
+        asChild
+        className="bg-background/80 font-mono text-muted-foreground/60 backdrop-blur-sm hover:bg-background/80 hover:text-muted-foreground"
+      >
+        <a
+          href="https://github.com/austin-smith/crapdash"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View on GitHub"
+        >
+          <Image
+            src="/github-mark.svg"
+            alt=""
+            width={12}
+            height={12}
+            data-icon="inline-start"
+            className="opacity-60 transition-opacity group-hover/button:opacity-100 dark:invert"
+          />
+          <span>{DEFAULT_APP_TITLE} {version}</span>
+        </a>
+      </Button>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- Make the footer GitHub affordance a single shadcn `Button asChild` link wrapping both icon and version text.
- Keep anchor semantics for GitHub navigation while expanding the clickable target to the full pill.
