### PR TITLE
Add service duplicate action

### DIFF
--- a/components/admin/admin-client.tsx
+++ b/components/admin/admin-client.tsx
@@ -43,7 +43,8 @@ import { DownloadIcon } from '@/components/ui/animated-icons/download';
 import { FilePenLineIcon } from '@/components/ui/animated-icons/file-pen-line';
 import { UploadIcon } from '@/components/ui/animated-icons/upload';
 import { importConfig } from '@/lib/actions';
-import { DEFAULT_APP_TITLE, type Category, type Service, type Preferences, type IconConfig } from '@/lib/types';
+import { createServiceDuplicateDraft } from '@/lib/service-duplicate';
+import { DEFAULT_APP_TITLE, type Category, type Service, type Preferences, type IconConfig, type ServiceFormData } from '@/lib/types';
 import { AppSettingsCard } from '@/components/admin/app-settings/app-settings-card';
 import { ConfigEditorDialog } from '@/components/admin/config-editor/config-editor-dialog';
 import { PageFooter } from '@/components/layout/footer/page-footer';
@@ -72,6 +73,7 @@ export function AdminClient({ appTitle, appLogo, categories: initialCategories, 
   const [serviceModalOpen, setServiceModalOpen] = useState(false);
   const [editingCategory, setEditingCategory] = useState<Category | undefined>();
   const [editingService, setEditingService] = useState<Service | undefined>();
+  const [serviceDraft, setServiceDraft] = useState<ServiceFormData | undefined>();
   const [searchQuery, setSearchQuery] = useState('');
   const [refreshKey, setRefreshKey] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -159,11 +161,19 @@ export function AdminClient({ appTitle, appLogo, categories: initialCategories, 
 
   const handleAddService = () => {
     setEditingService(undefined);
+    setServiceDraft(undefined);
     setServiceModalOpen(true);
   };
 
   const handleEditService = (service: Service) => {
     setEditingService(service);
+    setServiceDraft(undefined);
+    setServiceModalOpen(true);
+  };
+
+  const handleDuplicateService = (service: Service) => {
+    setEditingService(undefined);
+    setServiceDraft(createServiceDuplicateDraft(service, services));
     setServiceModalOpen(true);
   };
 
@@ -178,6 +188,7 @@ export function AdminClient({ appTitle, appLogo, categories: initialCategories, 
     setServiceModalOpen(open);
     if (!open) {
       setEditingService(undefined);
+      setServiceDraft(undefined);
     }
   };
 
@@ -422,6 +433,7 @@ export function AdminClient({ appTitle, appLogo, categories: initialCategories, 
                 services={filteredData.services}
                 categories={categories}
                 onEdit={handleEditService}
+                onDuplicate={handleDuplicateService}
                 onDeleted={handleRefresh}
                 cacheKey={refreshKey}
               />
@@ -442,6 +454,8 @@ export function AdminClient({ appTitle, appLogo, categories: initialCategories, 
           open={serviceModalOpen}
           onOpenChange={handleServiceModalClose}
           service={editingService}
+          initialValues={serviceDraft}
+          mode={editingService ? 'edit' : serviceDraft ? 'duplicate' : 'create'}
           categories={categories}
           onSuccess={handleRefresh}
           cacheKey={refreshKey}

--- a/components/admin/services/service-form-modal.tsx
+++ b/components/admin/services/service-form-modal.tsx
@@ -7,12 +7,14 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ServiceForm } from './service-form';
-import type { Category, Service } from '@/lib/types';
+import type { Category, Service, ServiceFormData } from '@/lib/types';
 
 interface ServiceFormModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   service?: Service;
+  initialValues?: ServiceFormData;
+  mode?: 'create' | 'duplicate' | 'edit';
   categories: Category[];
   onSuccess: () => void;
   cacheKey?: number;
@@ -22,6 +24,8 @@ export function ServiceFormModal({
   open,
   onOpenChange,
   service,
+  initialValues,
+  mode,
   categories,
   onSuccess,
   cacheKey,
@@ -30,15 +34,28 @@ export function ServiceFormModal({
     onSuccess();
     onOpenChange(false);
   };
+  const resolvedMode = mode ?? (service ? 'edit' : 'create');
+  const formKey = service
+    ? `edit:${service.id}`
+    : initialValues
+      ? `draft:${initialValues.name}:${initialValues.url}:${initialValues.categoryId}`
+      : 'create';
+  const title = resolvedMode === 'edit'
+    ? 'Edit Service'
+    : resolvedMode === 'duplicate'
+      ? 'Duplicate Service'
+      : 'Add Service';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]" aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>{service ? 'Edit Service' : 'Add Service'}</DialogTitle>
+          <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
         <ServiceForm
+          key={formKey}
           service={service}
+          initialValues={initialValues}
           categories={categories}
           onSuccess={handleSuccess}
           onCancel={() => onOpenChange(false)}

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -90,7 +90,7 @@ export function ServiceForm({ service, initialValues, categories, onSuccess, onC
   const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
   const [iconVersion, setIconVersion] = useState(0);
   const [iconControl, setIconControl] = useState<'auto' | 'manual'>(
-    service || initialValues?.icon ? 'manual' : 'auto'
+    hasSeededValues ? 'manual' : 'auto'
   );
   const urlRef = useRef(url);
   const nameRef = useRef(name);

--- a/components/admin/services/service-form.tsx
+++ b/components/admin/services/service-form.tsx
@@ -26,10 +26,11 @@ import {
   type ServiceMetadataApplyMode,
 } from '@/lib/service-metadata-apply';
 import { cn, slugify } from '@/lib/utils';
-import { ICON_TYPES, type Category, type IconConfig, type Service } from '@/lib/types';
+import { ICON_TYPES, type Category, type IconConfig, type Service, type ServiceFormData } from '@/lib/types';
 
 interface ServiceFormProps {
   service?: Service;
+  initialValues?: ServiceFormData;
   categories: Category[];
   onSuccess?: () => void;
   onCancel?: () => void;
@@ -73,25 +74,29 @@ function getIconFetchId(serviceId: string, serviceUrl: string): string {
   }
 }
 
-export function ServiceForm({ service, categories, onSuccess, onCancel, cacheKey }: ServiceFormProps) {
-  const [name, setName] = useState(service?.name || '');
-  const [description, setDescription] = useState(service?.description || '');
-  const [url, setUrl] = useState(service?.url || '');
-  const [categoryId, setCategoryId] = useState(service?.categoryId || '');
-  const [icon, setIcon] = useState<IconConfig | undefined>(service?.icon);
+export function ServiceForm({ service, initialValues, categories, onSuccess, onCancel, cacheKey }: ServiceFormProps) {
+  const formValues = service ?? initialValues;
+  const hasSeededValues = !!formValues;
+  const [name, setName] = useState(formValues?.name || '');
+  const [description, setDescription] = useState(formValues?.description || '');
+  const [url, setUrl] = useState(formValues?.url || '');
+  const [categoryId, setCategoryId] = useState(formValues?.categoryId || '');
+  const [icon, setIcon] = useState<IconConfig | undefined>(formValues?.icon);
   const [pendingIconFile, setPendingIconFile] = useState<File | null>(null);
-  const [active, setActive] = useState(service?.active ?? true);
+  const [active, setActive] = useState(formValues?.active ?? true);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isFetchingIcon, setIsFetchingIcon] = useState(false);
   const [isFetchingMetadata, setIsFetchingMetadata] = useState(false);
   const [iconVersion, setIconVersion] = useState(0);
-  const [iconControl, setIconControl] = useState<'auto' | 'manual'>(service ? 'manual' : 'auto');
+  const [iconControl, setIconControl] = useState<'auto' | 'manual'>(
+    service || initialValues?.icon ? 'manual' : 'auto'
+  );
   const urlRef = useRef(url);
   const nameRef = useRef(name);
   const descriptionRef = useRef(description);
-  const hasUserEditedNameRef = useRef(!!service);
-  const hasUserEditedDescriptionRef = useRef(!!service);
+  const hasUserEditedNameRef = useRef(hasSeededValues);
+  const hasUserEditedDescriptionRef = useRef(hasSeededValues);
   const lastAutoFetchKeyRef = useRef<string | null>(null);
   const lastAutoMetadataFetchKeyRef = useRef<string | null>(null);
   const autoFetchRequestRef = useRef(0);

--- a/components/admin/services/service-list.tsx
+++ b/components/admin/services/service-list.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 import { CornerRibbon } from '@/components/ui/corner-ribbon';
 import { CategoryIcon } from '@/components/common/icons/category-icon';
 import { SortableList, SortableItem } from '@/components/ui/sortable';
-import { Pencil, Trash2, ExternalLink } from 'lucide-react';
+import { ExternalLink, Pencil, Trash2 } from 'lucide-react';
 import { ServiceIcon } from '@/components/common/icons/service-icon';
 import { DeleteConfirmDialog } from '../delete-confirm-dialog';
 import { deleteService, reorderServices } from '@/lib/actions';
@@ -20,11 +20,12 @@ interface ServiceListProps {
   services: Service[];
   categories: Category[];
   onEdit: (service: Service) => void;
+  onDuplicate: (service: Service) => void;
   onDeleted: () => void;
   cacheKey?: number;
 }
 
-export function ServiceList({ services, categories, onEdit, onDeleted, cacheKey }: ServiceListProps) {
+export function ServiceList({ services, categories, onEdit, onDuplicate, onDeleted, cacheKey }: ServiceListProps) {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [serviceToDelete, setServiceToDelete] = useState<Service | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -218,6 +219,7 @@ export function ServiceList({ services, categories, onEdit, onDeleted, cacheKey 
                       <ServiceCardContext
                         service={service}
                         onEdit={onEdit}
+                        onDuplicate={onDuplicate}
                         onDelete={handleDeleteClick}
                         index={index}
                       >

--- a/components/common/context-menus/service-card-context.tsx
+++ b/components/common/context-menus/service-card-context.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Copy, ExternalLink, Pencil, Trash2 } from 'lucide-react';
+import { Clipboard, CopyPlus, ExternalLink, Pencil, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   ContextMenu,
@@ -16,6 +16,7 @@ interface ServiceCardContextProps {
   service: Service;
   children: React.ReactNode;
   onEdit: (service: Service) => void;
+  onDuplicate?: (service: Service) => void;
   onDelete: (service: Service) => void;
   index: number;
 }
@@ -28,6 +29,7 @@ export function ServiceCardContext({
   service,
   children,
   onEdit,
+  onDuplicate,
   onDelete,
   index,
 }: ServiceCardContextProps) {
@@ -75,9 +77,15 @@ export function ServiceCardContext({
           <Pencil />
           Edit
         </ContextMenuItem>
+        {onDuplicate && (
+          <ContextMenuItem onClick={() => onDuplicate(service)}>
+            <CopyPlus />
+            Duplicate
+          </ContextMenuItem>
+        )}
         <ContextMenuSeparator />
         <ContextMenuItem onClick={handleCopyUrl}>
-          <Copy />
+          <Clipboard />
           Copy URL
         </ContextMenuItem>
         <ContextMenuItem onClick={handleOpenInNewTab}>

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -143,9 +143,10 @@ async function deleteImageIconIfUnreferenced(iconPath: string | undefined, confi
   await deleteIconFile(iconPath);
 }
 
-function getDefaultServiceIconPath(iconPath: string, serviceId: string): string {
-  const ext = path.extname(path.basename(iconPath)).toLowerCase();
-  return `icons/${serviceId}${ext}`;
+function isServiceOwnedIconPath(iconPath: string, serviceId: string): boolean {
+  const iconBaseName = getIconPathBasename(iconPath);
+
+  return iconBaseName === serviceId || iconBaseName.startsWith(`${serviceId}-`);
 }
 
 async function getCreatedServiceIcon(
@@ -163,7 +164,11 @@ async function getCreatedServiceIcon(
   }
 
   try {
-    if (!reservedIconPaths.has(icon.value) && icon.value === getDefaultServiceIconPath(icon.value, serviceId)) {
+    if (
+      !reservedIconPaths.has(icon.value) &&
+      !reservedIconBasenames.has(getIconPathBasename(icon.value)) &&
+      isServiceOwnedIconPath(icon.value, serviceId)
+    ) {
       return icon;
     }
 

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -74,6 +74,15 @@ async function getPromotedServiceIcon(icon: IconConfig | undefined, serviceId: s
   };
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'ENOENT'
+  );
+}
+
 async function getCreatedServiceIcon(icon: IconConfig | undefined, serviceId: string): Promise<IconConfig | undefined> {
   if (icon?.type !== ICON_TYPES.IMAGE) {
     return icon;
@@ -90,10 +99,18 @@ async function getCreatedServiceIcon(icon: IconConfig | undefined, serviceId: st
     return icon;
   }
 
-  return {
-    type: ICON_TYPES.IMAGE,
-    value: await copyIconToService(icon.value, serviceId),
-  };
+  try {
+    return {
+      type: ICON_TYPES.IMAGE,
+      value: await copyIconToService(icon.value, serviceId),
+    };
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return undefined;
+    }
+
+    throw error;
+  }
 }
 
 function validateImageFile(file: File, fieldName: string): { success: false; errors: { field: string; message: string }[] } | null {

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -22,7 +22,6 @@ import {
   copyIconToService,
   deleteAppLogo,
   deleteIconFile,
-  deleteServiceIcon,
   getAppLogoFilename,
   isProvisionalIconPath,
   isValidImageExtension,
@@ -83,26 +82,40 @@ function isMissingFileError(error: unknown): boolean {
   );
 }
 
-async function getCreatedServiceIcon(icon: IconConfig | undefined, serviceId: string): Promise<IconConfig | undefined> {
+function getImageIconPath(icon: IconConfig | undefined): string | undefined {
+  return icon?.type === ICON_TYPES.IMAGE ? icon.value : undefined;
+}
+
+function isIconPathReferenced(iconPath: string, services: Service[]): boolean {
+  return services.some((service) => getImageIconPath(service.icon) === iconPath);
+}
+
+async function deleteUnreferencedImageIcon(iconPath: string | undefined, services: Service[]): Promise<void> {
+  if (!iconPath || isIconPathReferenced(iconPath, services)) return;
+
+  await deleteIconFile(iconPath);
+}
+
+async function getCreatedServiceIcon(
+  icon: IconConfig | undefined,
+  serviceId: string,
+  existingServices: Service[]
+): Promise<IconConfig | undefined> {
   if (icon?.type !== ICON_TYPES.IMAGE) {
     return icon;
   }
-
-  const filename = path.basename(icon.value);
-  const iconBaseName = path.parse(filename).name;
 
   if (isProvisionalIconPath(icon.value)) {
     return getPromotedServiceIcon(icon, serviceId);
   }
 
-  if (iconBaseName === serviceId) {
-    return icon;
-  }
-
   try {
+    const isExistingServiceIcon = isIconPathReferenced(icon.value, existingServices);
     return {
       type: ICON_TYPES.IMAGE,
-      value: await copyIconToService(icon.value, serviceId),
+      value: await copyIconToService(icon.value, serviceId, {
+        avoidIconPath: isExistingServiceIcon ? icon.value : undefined,
+      }),
     };
   } catch (error) {
     if (isMissingFileError(error)) {
@@ -666,7 +679,7 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
     let promotedIconPath: string | null = null;
     const newService: Service = {
       ...validated,
-      icon: await getCreatedServiceIcon(validated.icon, validated.id),
+      icon: await getCreatedServiceIcon(validated.icon, validated.id, config.services),
     };
     if (
       newService.icon?.type === ICON_TYPES.IMAGE &&
@@ -688,7 +701,7 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
       await writeConfig(config);
     } catch (error) {
       if (downloadedIconPath || promotedIconPath) {
-        await deleteServiceIcon(newService.id);
+        await deleteUnreferencedImageIcon(getImageIconPath(newService.icon), config.services.filter((service) => service.id !== newService.id));
       }
       throw error;
     }
@@ -766,13 +779,7 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
       throw error;
     }
 
-    // If we are moving away from an image icon, remove the old image file after the config persists
-    if (
-      previousService.icon?.type === ICON_TYPES.IMAGE &&
-      nextIcon?.type !== ICON_TYPES.IMAGE
-    ) {
-      await deleteServiceIcon(id);
-    }
+    await deleteUnreferencedImageIcon(getImageIconPath(previousService.icon), config.services);
 
     revalidatePath('/');
     revalidatePath('/admin');
@@ -798,12 +805,12 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
 export async function deleteService(id: string): Promise<ActionResult<void>> {
   try {
     const config = await readConfig();
+    const serviceToDelete = config.services.find(svc => svc.id === id);
 
     config.services = config.services.filter(svc => svc.id !== id);
     await writeConfig(config);
 
-    // Delete icon file if it exists
-    await deleteServiceIcon(id);
+    await deleteUnreferencedImageIcon(getImageIconPath(serviceToDelete?.icon), config.services);
 
     revalidatePath('/');
     revalidatePath('/admin');

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -19,6 +19,7 @@ import {
 } from './validations';
 import {
   backupServiceIconFiles,
+  copyIconToService,
   deleteAppLogo,
   deleteIconFile,
   deleteServiceIcon,
@@ -70,6 +71,28 @@ async function getPromotedServiceIcon(icon: IconConfig | undefined, serviceId: s
   return {
     type: ICON_TYPES.IMAGE,
     value: iconPath,
+  };
+}
+
+async function getCreatedServiceIcon(icon: IconConfig | undefined, serviceId: string): Promise<IconConfig | undefined> {
+  if (icon?.type !== ICON_TYPES.IMAGE) {
+    return icon;
+  }
+
+  const filename = path.basename(icon.value);
+  const iconBaseName = path.parse(filename).name;
+
+  if (isProvisionalIconPath(icon.value)) {
+    return getPromotedServiceIcon(icon, serviceId);
+  }
+
+  if (iconBaseName === serviceId) {
+    return icon;
+  }
+
+  return {
+    type: ICON_TYPES.IMAGE,
+    value: await copyIconToService(icon.value, serviceId),
   };
 }
 
@@ -626,7 +649,7 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
     let promotedIconPath: string | null = null;
     const newService: Service = {
       ...validated,
-      icon: await getPromotedServiceIcon(validated.icon, validated.id),
+      icon: await getCreatedServiceIcon(validated.icon, validated.id),
     };
     if (
       newService.icon?.type === ICON_TYPES.IMAGE &&

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -20,7 +20,6 @@ import {
 import {
   backupServiceIconFiles,
   copyIconToService,
-  deleteAppLogo,
   deleteIconFile,
   getAppLogoFilename,
   isProvisionalIconPath,
@@ -40,6 +39,7 @@ import {
   type ServiceFormData,
   type ServiceCreateData,
   type IconConfig,
+  type DashboardConfig,
   type ImportConfigResult,
 } from './types';
 
@@ -86,20 +86,39 @@ function getImageIconPath(icon: IconConfig | undefined): string | undefined {
   return icon?.type === ICON_TYPES.IMAGE ? icon.value : undefined;
 }
 
-function isIconPathReferenced(iconPath: string, services: Service[]): boolean {
-  return services.some((service) => getImageIconPath(service.icon) === iconPath);
+function getReferencedImageIconPaths(config: DashboardConfig): Set<string> {
+  const refs = new Set<string>();
+
+  const appLogoPath = getImageIconPath(config.appLogo);
+  if (appLogoPath) {
+    refs.add(appLogoPath);
+  }
+
+  for (const service of config.services) {
+    const iconPath = getImageIconPath(service.icon);
+    if (iconPath) {
+      refs.add(iconPath);
+    }
+  }
+
+  return refs;
 }
 
-async function deleteUnreferencedImageIcon(iconPath: string | undefined, services: Service[]): Promise<void> {
-  if (!iconPath || isIconPathReferenced(iconPath, services)) return;
+async function deleteImageIconIfUnreferenced(iconPath: string | undefined, config: DashboardConfig): Promise<void> {
+  if (!iconPath || getReferencedImageIconPaths(config).has(iconPath)) return;
 
   await deleteIconFile(iconPath);
+}
+
+function getDefaultServiceIconPath(iconPath: string, serviceId: string): string {
+  const ext = path.extname(path.basename(iconPath)).toLowerCase();
+  return `icons/${serviceId}${ext}`;
 }
 
 async function getCreatedServiceIcon(
   icon: IconConfig | undefined,
   serviceId: string,
-  existingServices: Service[]
+  reservedIconPaths: Set<string>
 ): Promise<IconConfig | undefined> {
   if (icon?.type !== ICON_TYPES.IMAGE) {
     return icon;
@@ -110,12 +129,13 @@ async function getCreatedServiceIcon(
   }
 
   try {
-    const isExistingServiceIcon = isIconPathReferenced(icon.value, existingServices);
+    if (!reservedIconPaths.has(icon.value) && icon.value === getDefaultServiceIconPath(icon.value, serviceId)) {
+      return icon;
+    }
+
     return {
       type: ICON_TYPES.IMAGE,
-      value: await copyIconToService(icon.value, serviceId, {
-        avoidIconPath: isExistingServiceIcon ? icon.value : undefined,
-      }),
+      value: await copyIconToService(icon.value, serviceId, { reservedIconPaths }),
     };
   } catch (error) {
     if (isMissingFileError(error)) {
@@ -506,15 +526,13 @@ export async function updateAppSettings(data: AppSettingsInput): Promise<ActionR
       const incomingLogo = validated.appLogo;
       if (incomingLogo === null) {
         nextConfig.appLogo = undefined;
-        if (previousAppLogoPath) {
-          await deleteAppLogo(previousAppLogoPath);
-        }
       } else if (incomingLogo !== undefined) {
         nextConfig.appLogo = incomingLogo;
       }
     }
 
     await writeConfig(nextConfig);
+    await deleteImageIconIfUnreferenced(previousAppLogoPath, nextConfig);
 
     revalidatePath('/');
     revalidatePath('/admin');
@@ -679,7 +697,7 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
     let promotedIconPath: string | null = null;
     const newService: Service = {
       ...validated,
-      icon: await getCreatedServiceIcon(validated.icon, validated.id, config.services),
+      icon: await getCreatedServiceIcon(validated.icon, validated.id, getReferencedImageIconPaths(config)),
     };
     if (
       newService.icon?.type === ICON_TYPES.IMAGE &&
@@ -701,7 +719,11 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
       await writeConfig(config);
     } catch (error) {
       if (downloadedIconPath || promotedIconPath) {
-        await deleteUnreferencedImageIcon(getImageIconPath(newService.icon), config.services.filter((service) => service.id !== newService.id));
+        const configWithoutNewService = {
+          ...config,
+          services: config.services.filter((service) => service.id !== newService.id),
+        };
+        await deleteImageIconIfUnreferenced(getImageIconPath(newService.icon), configWithoutNewService);
       }
       throw error;
     }
@@ -779,7 +801,7 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
       throw error;
     }
 
-    await deleteUnreferencedImageIcon(getImageIconPath(previousService.icon), config.services);
+    await deleteImageIconIfUnreferenced(getImageIconPath(previousService.icon), config);
 
     revalidatePath('/');
     revalidatePath('/admin');
@@ -810,7 +832,7 @@ export async function deleteService(id: string): Promise<ActionResult<void>> {
     config.services = config.services.filter(svc => svc.id !== id);
     await writeConfig(config);
 
-    await deleteUnreferencedImageIcon(getImageIconPath(serviceToDelete?.icon), config.services);
+    await deleteImageIconIfUnreferenced(getImageIconPath(serviceToDelete?.icon), config);
 
     revalidatePath('/');
     revalidatePath('/admin');

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -21,6 +21,7 @@ import {
   backupServiceIconFiles,
   copyIconToService,
   deleteIconFile,
+  getAvailableIconBaseName,
   getAppLogoFilename,
   isProvisionalIconPath,
   isValidImageExtension,
@@ -61,12 +62,20 @@ type SaveConfigJsonResult = ImportConfigResult & {
   revision: string;
 };
 
-async function getPromotedServiceIcon(icon: IconConfig | undefined, serviceId: string): Promise<IconConfig | undefined> {
+async function getPromotedServiceIcon(
+  icon: IconConfig | undefined,
+  serviceId: string,
+  protectedIconPaths?: Set<string>,
+  reservedIconBasenames?: Set<string>
+): Promise<IconConfig | undefined> {
   if (icon?.type !== ICON_TYPES.IMAGE || !isProvisionalIconPath(icon.value)) {
     return icon;
   }
 
-  const iconPath = await promoteProvisionalIcon(icon.value, serviceId);
+  const iconPath = await promoteProvisionalIcon(icon.value, serviceId, {
+    protectedIconPaths,
+    reservedIconBasenames,
+  });
   return {
     type: ICON_TYPES.IMAGE,
     value: iconPath,
@@ -86,15 +95,22 @@ function getImageIconPath(icon: IconConfig | undefined): string | undefined {
   return icon?.type === ICON_TYPES.IMAGE ? icon.value : undefined;
 }
 
-function getReferencedImageIconPaths(config: DashboardConfig): Set<string> {
+function getReferencedImageIconPaths(
+  config: DashboardConfig,
+  options: { excludeServiceId?: string; excludeAppLogo?: boolean } = {}
+): Set<string> {
   const refs = new Set<string>();
 
-  const appLogoPath = getImageIconPath(config.appLogo);
-  if (appLogoPath) {
-    refs.add(appLogoPath);
+  if (!options.excludeAppLogo) {
+    const appLogoPath = getImageIconPath(config.appLogo);
+    if (appLogoPath) {
+      refs.add(appLogoPath);
+    }
   }
 
   for (const service of config.services) {
+    if (service.id === options.excludeServiceId) continue;
+
     const iconPath = getImageIconPath(service.icon);
     if (iconPath) {
       refs.add(iconPath);
@@ -102,6 +118,23 @@ function getReferencedImageIconPaths(config: DashboardConfig): Set<string> {
   }
 
   return refs;
+}
+
+function getIconPathBasename(iconPath: string): string {
+  return path.parse(path.basename(iconPath)).name;
+}
+
+function getImageIconPathBasenames(iconPaths: Set<string>): Set<string> {
+  return new Set(
+    [...iconPaths].map((iconPath) => getIconPathBasename(iconPath))
+  );
+}
+
+function getReferencedImageIconBasenames(
+  config: DashboardConfig,
+  options: { excludeServiceId?: string; excludeAppLogo?: boolean } = {}
+): Set<string> {
+  return getImageIconPathBasenames(getReferencedImageIconPaths(config, options));
 }
 
 async function deleteImageIconIfUnreferenced(iconPath: string | undefined, config: DashboardConfig): Promise<void> {
@@ -118,14 +151,15 @@ function getDefaultServiceIconPath(iconPath: string, serviceId: string): string 
 async function getCreatedServiceIcon(
   icon: IconConfig | undefined,
   serviceId: string,
-  reservedIconPaths: Set<string>
+  reservedIconPaths: Set<string>,
+  reservedIconBasenames: Set<string>
 ): Promise<IconConfig | undefined> {
   if (icon?.type !== ICON_TYPES.IMAGE) {
     return icon;
   }
 
   if (isProvisionalIconPath(icon.value)) {
-    return getPromotedServiceIcon(icon, serviceId);
+    return getPromotedServiceIcon(icon, serviceId, reservedIconPaths, reservedIconBasenames);
   }
 
   try {
@@ -135,7 +169,7 @@ async function getCreatedServiceIcon(
 
     return {
       type: ICON_TYPES.IMAGE,
-      value: await copyIconToService(icon.value, serviceId, { reservedIconPaths }),
+      value: await copyIconToService(icon.value, serviceId, { reservedIconBasenames }),
     };
   } catch (error) {
     if (isMissingFileError(error)) {
@@ -159,11 +193,16 @@ function validateImageFile(file: File, fieldName: string): { success: false; err
   return null;
 }
 
-async function writeIconFile(file: File, filename: string, baseNameForCleanup: string): Promise<string> {
+async function writeIconFile(
+  file: File,
+  filename: string,
+  baseNameForCleanup: string,
+  protectedIconPaths?: Set<string>
+): Promise<string> {
   const bytes = await file.arrayBuffer();
   const buffer = Buffer.from(bytes);
 
-  return writeIconBuffer(buffer, filename, baseNameForCleanup);
+  return writeIconBuffer(buffer, filename, { baseNameForCleanup, protectedIconPaths });
 }
 
 function mapValidationIssues(error: ZodError): Array<{ field: string; message: string }> {
@@ -257,9 +296,15 @@ export async function uploadServiceIcon(formData: FormData): Promise<ActionResul
     const validationError = validateImageFile(file, 'icon');
     if (validationError) return validationError;
 
+    const config = await readConfig();
+    const protectedIconPaths = getReferencedImageIconPaths(config, { excludeServiceId: idValidation.data });
     const ext = path.extname(file.name).toLowerCase();
-    const filename = `${serviceId}${ext}`;
-    const iconPath = await writeIconFile(file, filename, serviceId);
+    const targetBaseName = getAvailableIconBaseName(
+      idValidation.data,
+      getImageIconPathBasenames(protectedIconPaths)
+    );
+    const filename = `${targetBaseName}${ext}`;
+    const iconPath = await writeIconFile(file, filename, targetBaseName, protectedIconPaths);
 
     return { success: true, data: iconPath };
   } catch (error) {
@@ -367,10 +412,15 @@ export async function uploadAppLogo(formData: FormData): Promise<ActionResult<st
     const validationError = validateImageFile(file, 'appLogo');
     if (validationError) return validationError;
 
+    const config = await readConfig();
+    const protectedIconPaths = getReferencedImageIconPaths(config, { excludeAppLogo: true });
     const ext = path.extname(file.name).toLowerCase();
     const filename = getAppLogoFilename(ext);
-    const baseName = path.parse(filename).name;
-    const iconPath = await writeIconFile(file, filename, baseName);
+    const targetBaseName = getAvailableIconBaseName(
+      path.parse(filename).name,
+      getImageIconPathBasenames(protectedIconPaths)
+    );
+    const iconPath = await writeIconFile(file, `${targetBaseName}${ext}`, targetBaseName, protectedIconPaths);
 
     return { success: true, data: iconPath };
   } catch (error) {
@@ -695,9 +745,11 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
 
     let downloadedIconPath: string | null = null;
     let promotedIconPath: string | null = null;
+    const reservedIconPaths = getReferencedImageIconPaths(config);
+    const reservedIconBasenames = getReferencedImageIconBasenames(config);
     const newService: Service = {
       ...validated,
-      icon: await getCreatedServiceIcon(validated.icon, validated.id, getReferencedImageIconPaths(config)),
+      icon: await getCreatedServiceIcon(validated.icon, validated.id, reservedIconPaths, reservedIconBasenames),
     };
     if (
       newService.icon?.type === ICON_TYPES.IMAGE &&
@@ -708,7 +760,10 @@ export async function createService(data: ServiceCreateData): Promise<ActionResu
     }
 
     if (!newService.icon && shouldFetchFavicon) {
-      downloadedIconPath = await fetchServiceFavicon(newService.url, newService.id);
+      downloadedIconPath = await fetchServiceFavicon(newService.url, newService.id, {
+        protectedIconPaths: reservedIconPaths,
+        reservedIconBasenames,
+      });
       if (downloadedIconPath) {
         newService.icon = { type: ICON_TYPES.IMAGE, value: downloadedIconPath };
       }
@@ -784,7 +839,20 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
       validated.icon?.type === ICON_TYPES.IMAGE && isProvisionalIconPath(validated.icon.value)
         ? await backupServiceIconFiles(idValidation.data)
         : null;
-    const nextIcon = await getPromotedServiceIcon(validated.icon, idValidation.data);
+    const protectedIconPaths = getReferencedImageIconPaths(config, { excludeServiceId: idValidation.data });
+    const nextIcon = await getPromotedServiceIcon(
+      validated.icon,
+      idValidation.data,
+      protectedIconPaths,
+      getImageIconPathBasenames(protectedIconPaths)
+    );
+    const promotedIconPath =
+      existingIconBackup &&
+      nextIcon?.type === ICON_TYPES.IMAGE &&
+      validated.icon?.type === ICON_TYPES.IMAGE &&
+      nextIcon.value !== validated.icon.value
+        ? nextIcon.value
+        : undefined;
     const updatedService: Service = {
       ...config.services[index],
       ...validated,
@@ -796,6 +864,9 @@ export async function updateService(id: string, data: ServiceFormData): Promise<
       await writeConfig(config);
     } catch (error) {
       if (existingIconBackup) {
+        if (promotedIconPath) {
+          await deleteIconFile(promotedIconPath);
+        }
         await restoreServiceIconFiles(idValidation.data, existingIconBackup);
       }
       throw error;

--- a/lib/favicon.ts
+++ b/lib/favicon.ts
@@ -6,7 +6,7 @@ import {
   isAllowedImageExtension,
   isAllowedImageMime,
 } from './image-constants';
-import { getProvisionalIconFilename, writeIconBuffer } from './file-utils';
+import { getAvailableIconBaseName, getProvisionalIconFilename, writeIconBuffer } from './file-utils';
 import {
   SERVICE_FETCH_USER_AGENT,
   fetchPageHtml,
@@ -232,12 +232,27 @@ async function findServiceFavicon(serviceUrl: string): Promise<{ buffer: Buffer;
   return null;
 }
 
-export async function fetchServiceFavicon(serviceUrl: string, serviceId: string): Promise<string | null> {
+export async function fetchServiceFavicon(
+  serviceUrl: string,
+  serviceId: string,
+  options: {
+    protectedIconPaths?: Set<string>;
+    reservedIconBasenames?: Set<string>;
+  } = {}
+): Promise<string | null> {
   try {
     const icon = await findServiceFavicon(serviceUrl);
     if (!icon) return null;
 
-    return writeIconBuffer(icon.buffer, `${serviceId}${icon.ext}`, serviceId);
+    const targetBaseName = getAvailableIconBaseName(
+      serviceId,
+      options.reservedIconBasenames ?? new Set<string>()
+    );
+
+    return writeIconBuffer(icon.buffer, `${targetBaseName}${icon.ext}`, {
+      baseNameForCleanup: targetBaseName,
+      protectedIconPaths: options.protectedIconPaths,
+    });
   } catch (error) {
     if (error instanceof Error && error.name !== 'TimeoutError' && error.name !== 'AbortError') {
       console.error('Favicon fetch error:', error);

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -159,7 +159,7 @@ export async function promoteProvisionalIcon(iconPath: string, serviceId: string
 export async function copyIconToService(
   iconPath: string,
   serviceId: string,
-  options: { avoidIconPath?: string } = {}
+  options: { reservedIconPaths?: Set<string> } = {}
 ): Promise<string> {
   if (!isManagedIconPath(iconPath)) {
     throw new Error('Only managed icon paths can be copied');
@@ -167,11 +167,13 @@ export async function copyIconToService(
 
   const filename = path.basename(iconPath);
   const ext = path.extname(filename).toLowerCase();
-  const defaultTargetFilename = `${serviceId}${ext}`;
-  const targetFilename =
-    options.avoidIconPath === `icons/${defaultTargetFilename}`
-      ? `${serviceId}-${randomUUID()}${ext}`
-      : defaultTargetFilename;
+  const reservedIconPaths = options.reservedIconPaths ?? new Set<string>();
+  let targetFilename = `${serviceId}${ext}`;
+
+  while (reservedIconPaths.has(`icons/${targetFilename}`)) {
+    targetFilename = `${serviceId}-${randomUUID()}${ext}`;
+  }
+
   const targetBaseName = path.parse(targetFilename).name;
   const buffer = await fs.readFile(getIconFilePath(filename));
   return writeIconBuffer(buffer, targetFilename, targetBaseName);

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -12,6 +12,21 @@ interface IconFileBackup {
   buffer: Buffer;
 }
 
+interface WriteIconBufferOptions {
+  baseNameForCleanup?: string;
+  protectedIconPaths?: Set<string>;
+}
+
+export function getAvailableIconBaseName(preferredBaseName: string, reservedIconBasenames: Set<string>): string {
+  let targetBaseName = preferredBaseName;
+
+  while (reservedIconBasenames.has(targetBaseName)) {
+    targetBaseName = `${preferredBaseName}-${randomUUID()}`;
+  }
+
+  return targetBaseName;
+}
+
 async function getIconFilesForBaseName(baseName: string): Promise<string[]> {
   const files = await fs.readdir(getIconsDir()).catch(() => []);
 
@@ -72,17 +87,20 @@ export function getIconFilePath(filename: string): string {
 export async function writeIconBuffer(
   buffer: Buffer,
   filename: string,
-  baseNameForCleanup?: string
+  options: WriteIconBufferOptions = {}
 ): Promise<string> {
   const filePath = getIconFilePath(filename);
   const iconsDir = path.dirname(filePath);
   const tempPath = path.join(iconsDir, `${filename}.tmp-${randomUUID()}`);
+  const { baseNameForCleanup, protectedIconPaths } = options;
 
   await fs.mkdir(iconsDir, { recursive: true });
 
   const existingIcons = baseNameForCleanup ? await fs.readdir(iconsDir).catch(() => []) : [];
   const oldFiles = existingIcons.filter((file) => (
-    path.parse(file).name === baseNameForCleanup && file !== filename
+    path.parse(file).name === baseNameForCleanup &&
+    file !== filename &&
+    !protectedIconPaths?.has(`icons/${file}`)
   ));
 
   try {
@@ -145,21 +163,35 @@ export function isManagedIconPath(iconPath: string): boolean {
   return iconPath === `icons/${filename}` && isValidImageExtension(filename);
 }
 
-export async function promoteProvisionalIcon(iconPath: string, serviceId: string): Promise<string> {
+export async function promoteProvisionalIcon(
+  iconPath: string,
+  serviceId: string,
+  options: {
+    protectedIconPaths?: Set<string>;
+    reservedIconBasenames?: Set<string>;
+  } = {}
+): Promise<string> {
   if (!isProvisionalIconPath(iconPath)) {
     throw new Error('Only provisional icons can be promoted');
   }
 
   const filename = path.basename(iconPath);
   const ext = path.extname(filename).toLowerCase();
+  const targetBaseName = getAvailableIconBaseName(
+    serviceId,
+    options.reservedIconBasenames ?? new Set<string>()
+  );
   const buffer = await fs.readFile(getIconFilePath(filename));
-  return writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
+  return writeIconBuffer(buffer, `${targetBaseName}${ext}`, {
+    baseNameForCleanup: targetBaseName,
+    protectedIconPaths: options.protectedIconPaths,
+  });
 }
 
 export async function copyIconToService(
   iconPath: string,
   serviceId: string,
-  options: { reservedIconPaths?: Set<string> } = {}
+  options: { reservedIconBasenames?: Set<string> } = {}
 ): Promise<string> {
   if (!isManagedIconPath(iconPath)) {
     throw new Error('Only managed icon paths can be copied');
@@ -167,16 +199,12 @@ export async function copyIconToService(
 
   const filename = path.basename(iconPath);
   const ext = path.extname(filename).toLowerCase();
-  const reservedIconPaths = options.reservedIconPaths ?? new Set<string>();
-  let targetFilename = `${serviceId}${ext}`;
+  const reservedIconBasenames = options.reservedIconBasenames ?? new Set<string>();
+  const targetBaseName = getAvailableIconBaseName(serviceId, reservedIconBasenames);
 
-  while (reservedIconPaths.has(`icons/${targetFilename}`)) {
-    targetFilename = `${serviceId}-${randomUUID()}${ext}`;
-  }
-
-  const targetBaseName = path.parse(targetFilename).name;
+  const targetFilename = `${targetBaseName}${ext}`;
   const buffer = await fs.readFile(getIconFilePath(filename));
-  return writeIconBuffer(buffer, targetFilename, targetBaseName);
+  return writeIconBuffer(buffer, targetFilename, { baseNameForCleanup: targetBaseName });
 }
 
 /**

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -139,9 +139,26 @@ export function isProvisionalIconPath(iconPath: string): boolean {
   );
 }
 
+export function isManagedIconPath(iconPath: string): boolean {
+  const filename = path.basename(iconPath);
+
+  return iconPath === `icons/${filename}` && isValidImageExtension(filename);
+}
+
 export async function promoteProvisionalIcon(iconPath: string, serviceId: string): Promise<string> {
   if (!isProvisionalIconPath(iconPath)) {
     throw new Error('Only provisional icons can be promoted');
+  }
+
+  const filename = path.basename(iconPath);
+  const ext = path.extname(filename).toLowerCase();
+  const buffer = await fs.readFile(getIconFilePath(filename));
+  return writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
+}
+
+export async function copyIconToService(iconPath: string, serviceId: string): Promise<string> {
+  if (!isManagedIconPath(iconPath)) {
+    throw new Error('Only managed icon paths can be copied');
   }
 
   const filename = path.basename(iconPath);

--- a/lib/file-utils.ts
+++ b/lib/file-utils.ts
@@ -156,15 +156,25 @@ export async function promoteProvisionalIcon(iconPath: string, serviceId: string
   return writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
 }
 
-export async function copyIconToService(iconPath: string, serviceId: string): Promise<string> {
+export async function copyIconToService(
+  iconPath: string,
+  serviceId: string,
+  options: { avoidIconPath?: string } = {}
+): Promise<string> {
   if (!isManagedIconPath(iconPath)) {
     throw new Error('Only managed icon paths can be copied');
   }
 
   const filename = path.basename(iconPath);
   const ext = path.extname(filename).toLowerCase();
+  const defaultTargetFilename = `${serviceId}${ext}`;
+  const targetFilename =
+    options.avoidIconPath === `icons/${defaultTargetFilename}`
+      ? `${serviceId}-${randomUUID()}${ext}`
+      : defaultTargetFilename;
+  const targetBaseName = path.parse(targetFilename).name;
   const buffer = await fs.readFile(getIconFilePath(filename));
-  return writeIconBuffer(buffer, `${serviceId}${ext}`, serviceId);
+  return writeIconBuffer(buffer, targetFilename, targetBaseName);
 }
 
 /**

--- a/lib/service-duplicate.ts
+++ b/lib/service-duplicate.ts
@@ -1,0 +1,37 @@
+import { ICON_TYPES, type Service, type ServiceFormData } from './types';
+import { slugify } from './utils';
+
+function getUniqueDuplicateName(sourceName: string, existingServices: Service[]): string {
+  const trimmedName = sourceName.trim();
+  const baseName = trimmedName || 'Service';
+  const existingIds = new Set(existingServices.map((service) => service.id));
+  const existingNames = new Set(existingServices.map((service) => service.name.trim().toLowerCase()));
+
+  for (let copyNumber = 1; copyNumber < Number.MAX_SAFE_INTEGER; copyNumber += 1) {
+    const suffix = copyNumber === 1 ? 'Copy' : `Copy ${copyNumber}`;
+    const candidateName = `${baseName} (${suffix})`;
+    const candidateId = slugify(candidateName);
+
+    if (candidateId && !existingIds.has(candidateId) && !existingNames.has(candidateName.toLowerCase())) {
+      return candidateName;
+    }
+  }
+
+  throw new Error('Unable to generate a unique service name');
+}
+
+export function createServiceDuplicateDraft(
+  service: Service,
+  existingServices: Service[]
+): ServiceFormData {
+  return {
+    name: getUniqueDuplicateName(service.name, existingServices),
+    description: service.description,
+    url: service.url,
+    categoryId: service.categoryId,
+    icon: service.icon?.type === ICON_TYPES.IMAGE
+      ? { type: ICON_TYPES.IMAGE, value: service.icon.value }
+      : service.icon,
+    active: service.active,
+  };
+}

--- a/lib/service-duplicate.ts
+++ b/lib/service-duplicate.ts
@@ -1,5 +1,14 @@
 import { ICON_TYPES, type Service, type ServiceFormData } from './types';
 import { slugify } from './utils';
+import { SERVICE_NAME_MAX_LENGTH } from './validations';
+
+function getDuplicateCandidateName(baseName: string, suffix: string): string {
+  const copySuffix = ` (${suffix})`;
+  const maxBaseLength = SERVICE_NAME_MAX_LENGTH - copySuffix.length;
+  const truncatedBaseName = baseName.slice(0, maxBaseLength).trimEnd();
+
+  return `${truncatedBaseName || 'Service'}${copySuffix}`;
+}
 
 function getUniqueDuplicateName(sourceName: string, existingServices: Service[]): string {
   const trimmedName = sourceName.trim();
@@ -9,7 +18,7 @@ function getUniqueDuplicateName(sourceName: string, existingServices: Service[])
 
   for (let copyNumber = 1; copyNumber < Number.MAX_SAFE_INTEGER; copyNumber += 1) {
     const suffix = copyNumber === 1 ? 'Copy' : `Copy ${copyNumber}`;
-    const candidateName = `${baseName} (${suffix})`;
+    const candidateName = getDuplicateCandidateName(baseName, suffix);
     const candidateId = slugify(candidateName);
 
     if (candidateId && !existingIds.has(candidateId) && !existingNames.has(candidateName.toLowerCase())) {

--- a/lib/service-duplicate.ts
+++ b/lib/service-duplicate.ts
@@ -1,6 +1,5 @@
-import { ICON_TYPES, type Service, type ServiceFormData } from './types';
+import { ICON_TYPES, SERVICE_NAME_MAX_LENGTH, type Service, type ServiceFormData } from './types';
 import { slugify } from './utils';
-import { SERVICE_NAME_MAX_LENGTH } from './validations';
 
 function getDuplicateCandidateName(baseName: string, suffix: string): string {
   const copySuffix = ` (${suffix})`;

--- a/lib/service-metadata.ts
+++ b/lib/service-metadata.ts
@@ -1,5 +1,5 @@
 import { parse, type DefaultTreeAdapterTypes } from 'parse5';
-import { SERVICE_DESCRIPTION_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH } from './validations';
+import { SERVICE_DESCRIPTION_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH } from './types';
 import { fetchPageHtml, isHttpUrl } from './service-url-fetch';
 
 export interface ServiceMetadata {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,8 @@ export type DashboardLayout = typeof LAYOUTS[keyof typeof LAYOUTS];
 export const DEFAULT_LAYOUT: DashboardLayout = LAYOUTS.ROWS;
 export const PREFERENCES_COOKIE_NAME = 'preferences';
 export const DEFAULT_APP_TITLE = 'crapdash';
+export const SERVICE_NAME_MAX_LENGTH = 100;
+export const SERVICE_DESCRIPTION_MAX_LENGTH = 500;
 
 export interface Preferences {
   layout: DashboardLayout;

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod';
-import { ICON_TYPES } from './types';
+import { ICON_TYPES, SERVICE_DESCRIPTION_MAX_LENGTH, SERVICE_NAME_MAX_LENGTH } from './types';
 import { resolveLucideIconName } from './lucide-icons';
-
-export const SERVICE_NAME_MAX_LENGTH = 100;
-export const SERVICE_DESCRIPTION_MAX_LENGTH = 500;
 
 export const slugSchema = z.string().regex(
   /^[a-z0-9-]+$/i,

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -1,7 +1,7 @@
 import { chmod, readFile, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanupFetchedServiceIcon, createService, updateService } from '@/lib/actions';
+import { cleanupFetchedServiceIcon, createService, deleteService, updateService } from '@/lib/actions';
 import { getConfigPath, getDataDir, getIconsDir } from '@/lib/paths';
 import { ICON_TYPES, type DashboardConfig } from '@/lib/types';
 import { createTestDataDir, removeTestDataDir } from './test-data-dir';
@@ -105,6 +105,51 @@ describe('service icon actions', () => {
 
     const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
     expect(savedConfig.services[1]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' });
+  });
+
+  it('keeps duplicated image icons isolated even when the source basename matches the new id', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' },
+        active: true,
+      }],
+    });
+    await writeIcon('grafana-copy.png', 'source icon');
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon?.type).toBe(ICON_TYPES.IMAGE);
+    expect(result.data.icon?.value).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
+    const duplicateIconFilename = path.basename(result.data.icon?.value ?? '');
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
+    await expect(readFile(path.join(getIconsDir(), duplicateIconFilename), 'utf-8')).resolves.toBe('source icon');
+
+    const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
+    expect(savedConfig.services[0]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' });
+    expect(savedConfig.services[1]?.icon).toEqual(result.data.icon);
+
+    const deleteResult = await deleteService('grafana-copy');
+
+    expect(deleteResult.success).toBe(true);
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
+    expect(await fileExists(duplicateIconFilename)).toBe(false);
   });
 
   it('creates the service without an icon when a copied image source file is missing', async () => {

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -71,6 +71,42 @@ describe('service icon actions', () => {
     expect(savedConfig.services[0]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' });
   });
 
+  it('copies an existing image icon when creating a service with a different id', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+        active: true,
+      }],
+    });
+    await writeIcon('grafana.png', 'source icon');
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana Copy',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' });
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('source icon');
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
+
+    const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
+    expect(savedConfig.services[1]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' });
+  });
+
   it('restores previous icon files when update config persistence fails after promotion', async () => {
     await writeConfig({
       categories: [{ id: 'infra', name: 'Infrastructure' }],

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -107,6 +107,40 @@ describe('service icon actions', () => {
     expect(savedConfig.services[1]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' });
   });
 
+  it('creates the service without an icon when a copied image source file is missing', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+        active: true,
+      }],
+    });
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon).toBeUndefined();
+    expect(await fileExists('grafana-copy.png')).toBe(false);
+
+    const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
+    expect(savedConfig.services[1]?.icon).toBeUndefined();
+  });
+
   it('restores previous icon files when update config persistence fails after promotion', async () => {
     await writeConfig({
       categories: [{ id: 'infra', name: 'Infrastructure' }],

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -1,7 +1,15 @@
-import { chmod, readFile, stat, writeFile } from 'fs/promises';
+import { chmod, readdir, readFile, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanupFetchedServiceIcon, createService, deleteService, updateAppSettings, updateService } from '@/lib/actions';
+import {
+  cleanupFetchedServiceIcon,
+  createService,
+  deleteService,
+  updateAppSettings,
+  updateService,
+  uploadAppLogo,
+  uploadServiceIcon,
+} from '@/lib/actions';
 import { getConfigPath, getDataDir, getIconsDir } from '@/lib/paths';
 import { ICON_TYPES, type DashboardConfig } from '@/lib/types';
 import { createTestDataDir, removeTestDataDir } from './test-data-dir';
@@ -197,6 +205,99 @@ describe('service icon actions', () => {
     await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('reserved icon');
   });
 
+  it('does not remove another referenced icon with the same basename and a different extension', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [
+        {
+          id: 'grafana',
+          name: 'Grafana',
+          description: 'Dashboards',
+          url: 'https://grafana.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+          active: true,
+        },
+        {
+          id: 'metrics',
+          name: 'Metrics',
+          description: 'Metrics',
+          url: 'https://metrics.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.svg' },
+          active: true,
+        },
+      ],
+    });
+    await writeIcon('grafana.png', 'source icon');
+    await writeIcon('grafana-copy.svg', 'reserved svg');
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon?.type).toBe(ICON_TYPES.IMAGE);
+    expect(result.data.icon?.value).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.svg'), 'utf-8')).resolves.toBe('reserved svg');
+  });
+
+  it('preserves referenced same-basename icons when uploading a service icon', async () => {
+    await writeConfig({
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' },
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [],
+    });
+    await writeIcon('grafana.svg', 'app logo');
+
+    const formData = new FormData();
+    formData.append('serviceId', 'grafana');
+    formData.append('file', new File(['service icon'], 'grafana.png', { type: 'image/png' }));
+
+    const result = await uploadServiceIcon(formData);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toMatch(/^icons\/grafana-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('app logo');
+    await expect(readFile(path.join(getIconsDir(), path.basename(result.data)), 'utf-8')).resolves.toBe('service icon');
+  });
+
+  it('preserves referenced same-basename icons when uploading an app logo', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/app-logo.svg' },
+        active: true,
+      }],
+    });
+    await writeIcon('app-logo.svg', 'service icon');
+
+    const formData = new FormData();
+    formData.append('file', new File(['app logo'], 'logo.png', { type: 'image/png' }));
+
+    const result = await uploadAppLogo(formData);
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data).toMatch(/^icons\/app-logo-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'app-logo.svg'), 'utf-8')).resolves.toBe('service icon');
+    await expect(readFile(path.join(getIconsDir(), path.basename(result.data)), 'utf-8')).resolves.toBe('app logo');
+  });
+
   it('does not overwrite the app logo when the default copy destination is already referenced by it', async () => {
     await writeConfig({
       appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' },
@@ -351,17 +452,29 @@ describe('service icon actions', () => {
   it('restores previous icon files when update config persistence fails after promotion', async () => {
     await writeConfig({
       categories: [{ id: 'infra', name: 'Infrastructure' }],
-      services: [{
-        id: 'grafana',
-        name: 'Grafana',
-        description: 'Dashboards',
-        url: 'https://grafana.example.com',
-        categoryId: 'infra',
-        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' },
-        active: true,
-      }],
+      services: [
+        {
+          id: 'grafana',
+          name: 'Grafana',
+          description: 'Dashboards',
+          url: 'https://grafana.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' },
+          active: true,
+        },
+        {
+          id: 'metrics',
+          name: 'Metrics',
+          description: 'Metrics',
+          url: 'https://metrics.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+          active: true,
+        },
+      ],
     });
     await writeIcon('grafana.svg', 'old icon');
+    await writeIcon('grafana.png', 'reserved icon');
     await writeIcon('__tmp-favicon-preview.ico', 'new icon');
     await chmod(getDataDir(), 0o555);
 
@@ -375,11 +488,15 @@ describe('service icon actions', () => {
     });
 
     expect(result.success).toBe(false);
+    const iconFiles = await readdir(getIconsDir());
     expect(await fileExists('grafana.ico')).toBe(false);
+    expect(iconFiles.filter((file) => /^grafana-[a-f0-9-]+\.ico$/.test(file))).toEqual([]);
     await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('old icon');
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('reserved icon');
 
     await chmod(getDataDir(), 0o755);
     const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
     expect(savedConfig.services[0]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.svg' });
+    expect(savedConfig.services[1]?.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' });
   });
 });

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -1,7 +1,7 @@
 import { chmod, readFile, stat, writeFile } from 'fs/promises';
 import path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanupFetchedServiceIcon, createService, deleteService, updateService } from '@/lib/actions';
+import { cleanupFetchedServiceIcon, createService, deleteService, updateAppSettings, updateService } from '@/lib/actions';
 import { getConfigPath, getDataDir, getIconsDir } from '@/lib/paths';
 import { ICON_TYPES, type DashboardConfig } from '@/lib/types';
 import { createTestDataDir, removeTestDataDir } from './test-data-dir';
@@ -152,6 +152,86 @@ describe('service icon actions', () => {
     expect(await fileExists(duplicateIconFilename)).toBe(false);
   });
 
+  it('does not overwrite another service icon when the default copy destination is already referenced', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [
+        {
+          id: 'grafana',
+          name: 'Grafana',
+          description: 'Dashboards',
+          url: 'https://grafana.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+          active: true,
+        },
+        {
+          id: 'metrics',
+          name: 'Metrics',
+          description: 'Metrics',
+          url: 'https://metrics.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' },
+          active: true,
+        },
+      ],
+    });
+    await writeIcon('grafana.png', 'source icon');
+    await writeIcon('grafana-copy.png', 'reserved icon');
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon?.type).toBe(ICON_TYPES.IMAGE);
+    expect(result.data.icon?.value).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('reserved icon');
+  });
+
+  it('does not overwrite the app logo when the default copy destination is already referenced by it', async () => {
+    await writeConfig({
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/grafana-copy.png' },
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+        active: true,
+      }],
+    });
+    await writeIcon('grafana.png', 'source icon');
+    await writeIcon('grafana-copy.png', 'app logo');
+
+    const result = await createService({
+      id: 'grafana-copy',
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.icon?.type).toBe(ICON_TYPES.IMAGE);
+    expect(result.data.icon?.value).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('app logo');
+  });
+
   it('creates the service without an icon when a copied image source file is missing', async () => {
     await writeConfig({
       categories: [{ id: 'infra', name: 'Infrastructure' }],
@@ -184,6 +264,88 @@ describe('service icon actions', () => {
 
     const savedConfig = JSON.parse(await readFile(getConfigPath(), 'utf-8')) as DashboardConfig;
     expect(savedConfig.services[1]?.icon).toBeUndefined();
+  });
+
+  it('does not delete a service icon file that is still referenced by the app logo', async () => {
+    await writeConfig({
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+        active: true,
+      }],
+    });
+    await writeIcon('shared.png', 'shared icon');
+
+    const result = await deleteService('grafana');
+
+    expect(result.success).toBe(true);
+    await expect(readFile(path.join(getIconsDir(), 'shared.png'), 'utf-8')).resolves.toBe('shared icon');
+  });
+
+  it('does not delete an updated service icon file that is still referenced by another service', async () => {
+    await writeConfig({
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [
+        {
+          id: 'grafana',
+          name: 'Grafana',
+          description: 'Dashboards',
+          url: 'https://grafana.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+          active: true,
+        },
+        {
+          id: 'metrics',
+          name: 'Metrics',
+          description: 'Metrics',
+          url: 'https://metrics.example.com',
+          categoryId: 'infra',
+          icon: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+          active: true,
+        },
+      ],
+    });
+    await writeIcon('shared.png', 'shared icon');
+
+    const result = await updateService('grafana', {
+      name: 'Grafana',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      active: true,
+    });
+
+    expect(result.success).toBe(true);
+    await expect(readFile(path.join(getIconsDir(), 'shared.png'), 'utf-8')).resolves.toBe('shared icon');
+  });
+
+  it('does not delete an app logo file that is still referenced by a service', async () => {
+    await writeConfig({
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [{
+        id: 'grafana',
+        name: 'Grafana',
+        description: 'Dashboards',
+        url: 'https://grafana.example.com',
+        categoryId: 'infra',
+        icon: { type: ICON_TYPES.IMAGE, value: 'icons/shared.png' },
+        active: true,
+      }],
+    });
+    await writeIcon('shared.png', 'shared icon');
+
+    const result = await updateAppSettings({ appLogo: null });
+
+    expect(result.success).toBe(true);
+    await expect(readFile(path.join(getIconsDir(), 'shared.png'), 'utf-8')).resolves.toBe('shared icon');
   });
 
   it('restores previous icon files when update config persistence fails after promotion', async () => {

--- a/tests/lib/actions.test.ts
+++ b/tests/lib/actions.test.ts
@@ -271,6 +271,42 @@ describe('service icon actions', () => {
     await expect(readFile(path.join(getIconsDir(), path.basename(result.data)), 'utf-8')).resolves.toBe('service icon');
   });
 
+  it('uses an unreferenced uploaded service icon without copying it again on create', async () => {
+    await writeConfig({
+      appLogo: { type: ICON_TYPES.IMAGE, value: 'icons/app-logo.png' },
+      categories: [{ id: 'infra', name: 'Infrastructure' }],
+      services: [],
+    });
+    await writeIcon('app-logo.png', 'app logo');
+
+    const formData = new FormData();
+    formData.append('serviceId', 'app-logo');
+    formData.append('file', new File(['service icon'], 'service.png', { type: 'image/png' }));
+    const uploadResult = await uploadServiceIcon(formData);
+
+    expect(uploadResult.success).toBe(true);
+    if (!uploadResult.success) return;
+    expect(uploadResult.data).toMatch(/^icons\/app-logo-[a-f0-9-]+\.png$/);
+
+    const createResult = await createService({
+      id: 'app-logo',
+      name: 'App Logo',
+      description: 'Service',
+      url: 'https://app-logo.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.IMAGE, value: uploadResult.data },
+      active: true,
+      fetchFavicon: false,
+    });
+
+    expect(createResult.success).toBe(true);
+    if (!createResult.success) return;
+    expect(createResult.data.icon).toEqual({ type: ICON_TYPES.IMAGE, value: uploadResult.data });
+    const iconFiles = await readdir(getIconsDir());
+    expect(iconFiles.filter((file) => /^app-logo-[a-f0-9-]+\.png$/.test(file))).toHaveLength(1);
+    await expect(readFile(path.join(getIconsDir(), path.basename(uploadResult.data)), 'utf-8')).resolves.toBe('service icon');
+  });
+
   it('preserves referenced same-basename icons when uploading an app logo', async () => {
     await writeConfig({
       categories: [{ id: 'infra', name: 'Infrastructure' }],

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -72,4 +72,18 @@ describe('file-utils icon persistence', () => {
     await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('source icon');
     await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
   });
+
+  it('chooses a unique target when the default copy destination is reserved', async () => {
+    await writeIcon('grafana.png', 'source icon');
+    await writeIcon('grafana-copy.png', 'reserved icon');
+
+    const copiedPath = await copyIconToService('icons/grafana.png', 'grafana-copy', {
+      reservedIconPaths: new Set(['icons/grafana-copy.png']),
+    });
+    const copiedFilename = path.basename(copiedPath);
+
+    expect(copiedPath).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('reserved icon');
+    await expect(readFile(path.join(getIconsDir(), copiedFilename), 'utf-8')).resolves.toBe('source icon');
+  });
 });

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -7,6 +7,7 @@ import {
   isProvisionalIconPath,
   promoteProvisionalIcon,
   restoreServiceIconFiles,
+  writeIconBuffer,
 } from '@/lib/file-utils';
 import { getIconsDir } from '@/lib/paths';
 import { createTestDataDir, removeTestDataDir } from './test-data-dir';
@@ -73,17 +74,33 @@ describe('file-utils icon persistence', () => {
     await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
   });
 
-  it('chooses a unique target when the default copy destination is reserved', async () => {
+  it('chooses a unique target when the default copy basename is reserved', async () => {
     await writeIcon('grafana.png', 'source icon');
-    await writeIcon('grafana-copy.png', 'reserved icon');
+    await writeIcon('grafana-copy.svg', 'reserved icon');
 
     const copiedPath = await copyIconToService('icons/grafana.png', 'grafana-copy', {
-      reservedIconPaths: new Set(['icons/grafana-copy.png']),
+      reservedIconBasenames: new Set(['grafana-copy']),
     });
     const copiedFilename = path.basename(copiedPath);
 
     expect(copiedPath).toMatch(/^icons\/grafana-copy-[a-f0-9-]+\.png$/);
-    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('reserved icon');
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.svg'), 'utf-8')).resolves.toBe('reserved icon');
     await expect(readFile(path.join(getIconsDir(), copiedFilename), 'utf-8')).resolves.toBe('source icon');
+  });
+
+  it('preserves protected icon paths during same-basename cleanup', async () => {
+    await writeIcon('grafana.svg', 'protected icon');
+    await writeIcon('grafana.ico', 'stale icon');
+
+    await writeIconBuffer(Buffer.from('new icon'), 'grafana.png', {
+      baseNameForCleanup: 'grafana',
+      protectedIconPaths: new Set(['icons/grafana.svg']),
+    });
+
+    const files = await readdir(getIconsDir());
+    expect(files).toEqual(expect.arrayContaining(['grafana.svg', 'grafana.png']));
+    expect(files).not.toContain('grafana.ico');
+    await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('protected icon');
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('new icon');
   });
 });

--- a/tests/lib/file-utils.test.ts
+++ b/tests/lib/file-utils.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   backupServiceIconFiles,
+  copyIconToService,
   isProvisionalIconPath,
   promoteProvisionalIcon,
   restoreServiceIconFiles,
@@ -58,5 +59,17 @@ describe('file-utils icon persistence', () => {
     expect(files).toEqual(expect.arrayContaining(['__tmp-favicon-preview.ico', 'grafana.svg']));
     expect(files).not.toContain('grafana.ico');
     await expect(readFile(path.join(getIconsDir(), 'grafana.svg'), 'utf-8')).resolves.toBe('old icon');
+  });
+
+  it('copies a managed icon to a new service basename', async () => {
+    await writeIcon('grafana.png', 'source icon');
+
+    const copiedPath = await copyIconToService('icons/grafana.png', 'grafana-copy');
+    const files = await readdir(getIconsDir());
+
+    expect(copiedPath).toBe('icons/grafana-copy.png');
+    expect(files).toEqual(expect.arrayContaining(['grafana.png', 'grafana-copy.png']));
+    await expect(readFile(path.join(getIconsDir(), 'grafana.png'), 'utf-8')).resolves.toBe('source icon');
+    await expect(readFile(path.join(getIconsDir(), 'grafana-copy.png'), 'utf-8')).resolves.toBe('source icon');
   });
 });

--- a/tests/lib/service-duplicate.test.ts
+++ b/tests/lib/service-duplicate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { createServiceDuplicateDraft } from '@/lib/service-duplicate';
+import { ICON_TYPES, type Service } from '@/lib/types';
+
+const baseService: Service = {
+  id: 'grafana',
+  name: 'Grafana',
+  description: 'Dashboards',
+  url: 'https://grafana.example.com',
+  categoryId: 'infra',
+  icon: { type: ICON_TYPES.ICON, value: 'ChartNoAxesColumn' },
+  active: true,
+};
+
+describe('service duplicate helpers', () => {
+  it('creates a create-mode draft with a unique copy name', () => {
+    const draft = createServiceDuplicateDraft(baseService, [baseService]);
+
+    expect(draft).toEqual({
+      name: 'Grafana (Copy)',
+      description: 'Dashboards',
+      url: 'https://grafana.example.com',
+      categoryId: 'infra',
+      icon: { type: ICON_TYPES.ICON, value: 'ChartNoAxesColumn' },
+      active: true,
+    });
+  });
+
+  it('increments the copy name when either the name or slug already exists', () => {
+    const draft = createServiceDuplicateDraft(baseService, [
+      baseService,
+      { ...baseService, id: 'grafana-copy', name: 'Grafana Backup' },
+      { ...baseService, id: 'grafana-copy-2', name: 'Grafana (Copy 2)' },
+    ]);
+
+    expect(draft.name).toBe('Grafana (Copy 3)');
+  });
+
+  it('preserves image icon references for the create action to copy under the new service id', () => {
+    const draft = createServiceDuplicateDraft({
+      ...baseService,
+      icon: { type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' },
+    }, [baseService]);
+
+    expect(draft.icon).toEqual({ type: ICON_TYPES.IMAGE, value: 'icons/grafana.png' });
+  });
+});

--- a/tests/lib/service-duplicate.test.ts
+++ b/tests/lib/service-duplicate.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createServiceDuplicateDraft } from '@/lib/service-duplicate';
 import { ICON_TYPES, type Service } from '@/lib/types';
+import { SERVICE_NAME_MAX_LENGTH } from '@/lib/validations';
 
 const baseService: Service = {
   id: 'grafana',
@@ -34,6 +35,33 @@ describe('service duplicate helpers', () => {
     ]);
 
     expect(draft.name).toBe('Grafana (Copy 3)');
+  });
+
+  it('truncates long service names before appending the copy suffix', () => {
+    const longName = 'A'.repeat(SERVICE_NAME_MAX_LENGTH);
+    const draft = createServiceDuplicateDraft({
+      ...baseService,
+      id: 'long-service',
+      name: longName,
+    }, [{ ...baseService, id: 'long-service', name: longName }]);
+
+    expect(draft.name).toBe(`${'A'.repeat(93)} (Copy)`);
+    expect(draft.name).toHaveLength(SERVICE_NAME_MAX_LENGTH);
+  });
+
+  it('reserves enough room when an incremented copy suffix is needed', () => {
+    const longName = 'A'.repeat(SERVICE_NAME_MAX_LENGTH);
+    const draft = createServiceDuplicateDraft({
+      ...baseService,
+      id: 'long-service',
+      name: longName,
+    }, [
+      { ...baseService, id: 'long-service', name: longName },
+      { ...baseService, id: `${'a'.repeat(93)}-copy`, name: `${'A'.repeat(93)} (Copy)` },
+    ]);
+
+    expect(draft.name).toBe(`${'A'.repeat(91)} (Copy 2)`);
+    expect(draft.name).toHaveLength(SERVICE_NAME_MAX_LENGTH);
   });
 
   it('preserves image icon references for the create action to copy under the new service id', () => {

--- a/tests/lib/service-duplicate.test.ts
+++ b/tests/lib/service-duplicate.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { createServiceDuplicateDraft } from '@/lib/service-duplicate';
-import { ICON_TYPES, type Service } from '@/lib/types';
-import { SERVICE_NAME_MAX_LENGTH } from '@/lib/validations';
+import { ICON_TYPES, SERVICE_NAME_MAX_LENGTH, type Service } from '@/lib/types';
 
 const baseService: Service = {
   id: 'grafana',


### PR DESCRIPTION
## Summary
- add a right-click `Duplicate` action for services
- open the service form in create mode with copied service fields
- generate collision-safe copy names/slugs and copy image icons to the new service id
